### PR TITLE
chore: support development of extension in windows

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,7 +4,10 @@ on: [push]
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        platform: [macos-latest, ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/package-lock.json
+++ b/package-lock.json
@@ -2324,6 +2324,10 @@
       "resolved": "https://registry.npmjs.org/@dcl/ecs-math/-/ecs-math-2.0.1-20221129185242.commit-40495c1.tgz",
       "integrity": "sha512-PzIXiZLL3SLqYAam++tQ9de0bkscABKC2ItwhMj3SITTb1UykBMpC/fBRPz6HJzd4gIOb/asUiha41IKOl7xUA=="
     },
+    "node_modules/@dcl/ecs/node_modules/@dcl/js-runtime": {
+      "resolved": "node_modules/@dcl/js-runtime",
+      "link": true
+    },
     "node_modules/@dcl/ecs/node_modules/@dcl/protocol": {
       "version": "1.0.0-4114477251.commit-ccb88d6",
       "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-4114477251.commit-ccb88d6.tgz",
@@ -2516,6 +2520,10 @@
         "react": "^18.2.0",
         "react-reconciler": "^0.29.0"
       }
+    },
+    "node_modules/@dcl/react-ecs/node_modules/@dcl/ecs": {
+      "resolved": "node_modules/@dcl/ecs",
+      "link": true
     },
     "node_modules/@dcl/rpc": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -395,8 +395,8 @@
     "deploy": "vsce publish",
     "test": "jest",
     "test:coverage": "jest --coverage",
-    "build": "./scripts/build.js",
-    "build-debug": "./scripts/build.js --debug"
+    "build": "node scripts/build.js",
+    "build-debug": "node scripts/build.js --debug"
   },
   "devDependencies": {
     "@types/cross-spawn": "^6.0.2",

--- a/src/modules/bin.spec.ts
+++ b/src/modules/bin.spec.ts
@@ -1,5 +1,6 @@
 import { bin, link } from './bin'
 import { setGlobalStoragePath, setExtensionPath } from './path'
+import { convertSlashToInvertSlashIfWin32 } from './../utils'
 
 /********************************************************
                           Mocks
@@ -77,7 +78,7 @@ describe('bin', () => {
       bin('decentraland', 'dcl', ['start'])
       expect(spawn).toBeCalledWith(
         expect.any(String),
-        '"/globalStorage/node"',
+        convertSlashToInvertSlashIfWin32('"/globalStorage/node"'),
         expect.any(Array),
         expect.any(Object)
       )
@@ -87,7 +88,7 @@ describe('bin', () => {
       expect(spawn).toBeCalledWith(
         expect.any(String),
         expect.any(String),
-        ['/extension/node_modules/decentraland/index.js', expect.any(String)],
+        [convertSlashToInvertSlashIfWin32('/extension/node_modules/decentraland/index.js'), expect.any(String)],
         expect.any(Object)
       )
     }),
@@ -159,7 +160,7 @@ describe('bin', () => {
         bin('decentraland', 'dcl')
         expect(spawn).toBeCalledWith(
           expect.any(String),
-          '"/globalStorage with white spaces/node"',
+          convertSlashToInvertSlashIfWin32('"/globalStorage with white spaces/node"'),
           [expect.any(String)],
           expect.any(Object)
         )
@@ -180,7 +181,7 @@ describe('bin', () => {
         bin('decentraland', 'dcl')
         expect(spawn).toBeCalledWith(
           expect.any(String),
-          '"/globalStorage/node.cmd"',
+          convertSlashToInvertSlashIfWin32('"/globalStorage/node.cmd"'),
           [expect.any(String)],
           expect.any(Object)
         )

--- a/src/modules/node.spec.ts
+++ b/src/modules/node.spec.ts
@@ -13,6 +13,8 @@ import {
 } from './node'
 import { getGlobalBinPath, setGlobalStoragePath } from './path'
 
+import { convertSlashToInvertSlashIfWin32 } from './../utils'
+
 /********************************************************
                           Mocks
 *********************************************************/
@@ -446,8 +448,8 @@ describe('node', () => {
         it('should link the node binaries', async () => {
           await checkNodeBinaries()
           expect(linkMock).toHaveBeenCalledWith(
-            '/globalStorage/node',
-            '/globalStorage/bin/node-v0.0.0-test-darwin-arm64/bin/node'
+            convertSlashToInvertSlashIfWin32('/globalStorage/node'),
+            convertSlashToInvertSlashIfWin32('/globalStorage/bin/node-v0.0.0-test-darwin-arm64/bin/node')
           )
         })
       })
@@ -525,7 +527,7 @@ describe('node', () => {
             it('should create the bin directory', async () => {
               await checkNodeBinaries()
               expect(fsMkdirSyncMock).toHaveBeenCalledWith(
-                '/globalStorage/bin',
+                convertSlashToInvertSlashIfWin32('/globalStorage/bin'),
                 {
                   recursive: true,
                 }
@@ -534,22 +536,22 @@ describe('node', () => {
             it('should uninstall the old distribution', async () => {
               await checkNodeBinaries()
               expect(rimrafMock).toHaveBeenCalledWith(
-                '/globalStorage/bin/node-v16.1.0-win-x64',
+                convertSlashToInvertSlashIfWin32('/globalStorage/bin/node-v16.1.0-win-x64'),
                 expect.any(Function)
               )
             })
             it('should unlink the old distribution', async () => {
               await checkNodeBinaries()
               expect(rimrafMock).toHaveBeenCalledWith(
-                '/globalStorage/node',
+                convertSlashToInvertSlashIfWin32('/globalStorage/node'),
                 expect.any(Function)
               )
             })
             it('should link the node binaries', async () => {
               await checkNodeBinaries()
               expect(linkMock).toHaveBeenCalledWith(
-                '/globalStorage/node',
-                '/globalStorage/bin/node-v16.2.0-darwin-arm64/bin/node'
+                convertSlashToInvertSlashIfWin32('/globalStorage/node'),
+                convertSlashToInvertSlashIfWin32('/globalStorage/bin/node-v16.2.0-darwin-arm64/bin/node')
               )
             })
           })

--- a/src/modules/path.spec.ts
+++ b/src/modules/path.spec.ts
@@ -8,6 +8,7 @@ import {
   setExtensionPath,
   setGlobalStoragePath,
 } from './path'
+import { convertSlashToInvertSlashIfWin32, addDriveIfWin32 } from './../utils'
 
 /********************************************************
                           Mocks
@@ -101,7 +102,7 @@ describe('path', () => {
       describe('and the command is part of the binaries', () => {
         it('should return the path to the bin file', () => {
           expect(getModuleBinPath('some-module', 'cmd')).toBe(
-            '/path/to/extension/node_modules/some-module/path/to/cmd.js'
+            convertSlashToInvertSlashIfWin32('/path/to/extension/node_modules/some-module/path/to/cmd.js')
           )
         })
       })
@@ -155,7 +156,7 @@ describe('path', () => {
       })
       it('should return the path to the Windows node bin', () => {
         expect(getNodeBinPath()).toBe(
-          '/globalStorage/bin/node-v1.0.0-win-x64/node.exe'
+          convertSlashToInvertSlashIfWin32('/globalStorage/bin/node-v1.0.0-win-x64/node.exe')
         )
       })
     })
@@ -178,7 +179,7 @@ describe('path', () => {
       })
       it('should return the path to the MacOS node bin', () => {
         expect(getNodeBinPath()).toBe(
-          '/globalStorage/bin/node-v1.0.0-darwin-arm64/bin/node'
+          convertSlashToInvertSlashIfWin32('/globalStorage/bin/node-v1.0.0-darwin-arm64/bin/node')
         )
       })
     })
@@ -234,8 +235,8 @@ describe('path', () => {
       })
       it('should return the two files', () => {
         expect(getFilePaths('/some/folder')).toEqual([
-          '/some/folder/file1.txt',
-          '/some/folder/file2.txt',
+          addDriveIfWin32(convertSlashToInvertSlashIfWin32('/some/folder/file1.txt')),
+          addDriveIfWin32(convertSlashToInvertSlashIfWin32('/some/folder/file2.txt')),
         ])
       })
     })
@@ -273,10 +274,10 @@ describe('path', () => {
       })
       it('should include the files in the subfolder', () => {
         expect(getFilePaths('/some/folder')).toEqual([
-          '/some/folder/file1.txt',
-          '/some/folder/file2.txt',
-          '/some/folder/subfolder/subfile1.txt',
-          '/some/folder/subfolder/subfile2.txt',
+          addDriveIfWin32(convertSlashToInvertSlashIfWin32('/some/folder/file1.txt')),
+          addDriveIfWin32(convertSlashToInvertSlashIfWin32('/some/folder/file2.txt')),
+          addDriveIfWin32(convertSlashToInvertSlashIfWin32('/some/folder/subfolder/subfile1.txt')),
+          addDriveIfWin32(convertSlashToInvertSlashIfWin32('/some/folder/subfolder/subfile2.txt')),
         ])
       })
     })

--- a/src/modules/pkg.spec.ts
+++ b/src/modules/pkg.spec.ts
@@ -1,4 +1,5 @@
 import { getPackageJson, getPackageVersion, hasDependency } from './pkg'
+import { convertSlashToInvertSlashIfWin32 } from './../utils'
 
 /********************************************************
                           Mocks
@@ -39,7 +40,7 @@ describe('pkg', () => {
     it('should read the package.json of the extension', () => {
       getPackageJson()
       expect(fsReadFileSyncMock).toHaveBeenCalledWith(
-        '/path/to/extension/package.json',
+        convertSlashToInvertSlashIfWin32('/path/to/extension/package.json'),
         'utf8'
       )
     })
@@ -51,7 +52,7 @@ describe('pkg', () => {
     it('should read the package.json from the workspace', () => {
       getPackageJson(null, true)
       expect(fsReadFileSyncMock).toHaveBeenCalledWith(
-        '/path/to/workspace/package.json',
+        convertSlashToInvertSlashIfWin32('/path/to/workspace/package.json'),
         'utf8'
       )
     })
@@ -65,7 +66,7 @@ describe('pkg', () => {
     it('should read the package.json from that module', () => {
       getPackageJson('some-module')
       expect(fsReadFileSyncMock).toHaveBeenCalledWith(
-        '/path/to/extension/node_modules/some-module/package.json',
+        convertSlashToInvertSlashIfWin32('/path/to/extension/node_modules/some-module/package.json'),
         'utf8'
       )
     })
@@ -89,7 +90,7 @@ describe('pkg', () => {
     it('should read the package.json from that module in the workspace', () => {
       getPackageJson('some-module', true)
       expect(fsReadFileSyncMock).toHaveBeenCalledWith(
-        '/path/to/workspace/node_modules/some-module/package.json',
+        convertSlashToInvertSlashIfWin32('/path/to/workspace/node_modules/some-module/package.json'),
         'utf8'
       )
     })
@@ -98,7 +99,7 @@ describe('pkg', () => {
     it('should read the package.json from that module', () => {
       getPackageVersion('some-module')
       expect(fsReadFileSyncMock).toHaveBeenCalledWith(
-        '/path/to/extension/node_modules/some-module/package.json',
+        convertSlashToInvertSlashIfWin32('/path/to/extension/node_modules/some-module/package.json'),
         'utf8'
       )
     })

--- a/src/modules/watch.spec.ts
+++ b/src/modules/watch.spec.ts
@@ -1,5 +1,7 @@
 import { watch, unwatch } from './watch'
 
+import { convertSlashToInvertSlashIfWin32 } from './../utils'
+
 /********************************************************
                           Mocks
 *********************************************************/
@@ -51,7 +53,7 @@ describe('watch', () => {
   describe('When watching', () => {
     it('should watch the node_modules directory of the workspace', () => {
       watch()
-      expect(watchSpy).toHaveBeenCalledWith('/path/to/workspace/node_modules')
+      expect(watchSpy).toHaveBeenCalledWith(convertSlashToInvertSlashIfWin32('/path/to/workspace/node_modules'))
     })
     it('refresh the tree when a change is detected ', () => {
       watch()
@@ -64,7 +66,7 @@ describe('watch', () => {
       watch()
       unwatch()
       expect(watcherMock.unwatch).toHaveBeenCalledWith(
-        '/path/to/workspace/node_modules'
+        convertSlashToInvertSlashIfWin32('/path/to/workspace/node_modules')
       )
     })
   })

--- a/src/modules/workspace.spec.ts
+++ b/src/modules/workspace.spec.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode'
+import { convertSlashToInvertSlashIfWin32 } from './../utils'
 
 import { getCwd, getScene, hasNodeModules, isDCL, isEmpty } from './workspace'
 
@@ -37,10 +38,10 @@ describe('workspace', () => {
       let realWorkspaceFolders = vscode.workspace
         .workspaceFolders as vscode.WorkspaceFolder[]
       beforeAll(() => {
-        ;(vscode.workspace.workspaceFolders as vscode.WorkspaceFolder[]) = []
+        ; (vscode.workspace.workspaceFolders as vscode.WorkspaceFolder[]) = []
       })
       afterAll(() => {
-        ;(vscode.workspace.workspaceFolders as vscode.WorkspaceFolder[]) =
+        ; (vscode.workspace.workspaceFolders as vscode.WorkspaceFolder[]) =
           realWorkspaceFolders
       })
       it('should throw', () => {
@@ -58,7 +59,7 @@ describe('workspace', () => {
     it('should read the scene json file from the file system', () => {
       getScene()
       expect(fsReadFileSyncMock).toHaveBeenCalledWith(
-        '/path/to/workspace/scene.json',
+        convertSlashToInvertSlashIfWin32('/path/to/workspace/scene.json'),
         'utf8'
       )
     })

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -34,3 +34,24 @@ export function getServerParams(server: ServerName) {
       return ''
   }
 }
+
+const WIN = process.platform === 'win32'
+const WIN_DRIVE = WIN ? require('path').resolve('/').substring(0, 2) : ''
+
+/**
+ * Convert regular slash to invert slash, only if it's running in win32 platform
+ * @param str string to convert
+ * @returns Converted string
+ */
+export function convertSlashToInvertSlashIfWin32(str: string) {
+  return WIN ? str.replace(/\//g, '\\') : str
+}
+
+/**
+ * Add the default unit drive when it's running in win32 platform
+ * @param str string to convert
+ * @returns Converted string
+ */
+export function addDriveIfWin32(str: string) {
+  return WIN_DRIVE + str
+}


### PR DESCRIPTION
# What?
Add most of the resolved path to test against inverted slashes

# Why?
Windows is a target platform for the editor, supporting the development and adding tests for that platform is very useful.