### PR TITLE
fix: avoid using global npm

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -4,7 +4,7 @@ import { npmInstall } from '../modules/npm'
 import { bin } from '../modules/bin'
 
 export async function init() {
-  const child = bin('@dcl/sdk', 'sdk-commands', ['init'])
+  const child = bin('@dcl/sdk', 'sdk-commands', ['init', '--skip-install'])
 
   await loader(
     `Creating project...`,

--- a/src/modules/bin.ts
+++ b/src/modules/bin.ts
@@ -21,7 +21,7 @@ export function bin(
   const node = fixWhiteSpaces(getNodeCmdPath())
   const bin = getModuleBinPath(moduleName, command)
   return spawn(
-    args[0] ? `${command} ${args[0]}` : command,
+    args.length > 0 ? `${command} ${args.join(' ').trim()}` : command,
     node,
     [bin, ...(args.filter((arg: string | undefined) => !!arg) as string[])],
     options


### PR DESCRIPTION
This PR adds the `--skip-install` flag to avoid using the global npm (which might not exist)