### PR TITLE
ci: support latest releases

### DIFF
--- a/.github/workflows/build-deploy.yaml
+++ b/.github/workflows/build-deploy.yaml
@@ -26,7 +26,7 @@ jobs:
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
       - name: Publish
         if: success() && startsWith(github.ref, 'refs/tags/')
-        run: git config --global user.name "decentraland" && git config --global user.email "muna@decentraland.org" && git stash && echo "DCL_EDITOR_SDK7_ROLLBAR_KEY=${{ env.DCL_EDITOR_SDK7_ROLLBAR_KEY }}" >> .env && echo "DCL_EDITOR_SDK7_SEGMENT_KEY=${{ env.DCL_EDITOR_SDK7_SEGMENT_KEY }}" >> .env && npx vsce publish ${{ env.RELEASE_VERSION }} --pre-release
+        run: git config --global user.name "decentraland" && git config --global user.email "muna@decentraland.org" && git stash && echo "DCL_EDITOR_SDK7_ROLLBAR_KEY=${{ env.DCL_EDITOR_SDK7_ROLLBAR_KEY }}" >> .env && echo "DCL_EDITOR_SDK7_SEGMENT_KEY=${{ env.DCL_EDITOR_SDK7_SEGMENT_KEY }}" >> .env && npx vsce publish ${{ env.RELEASE_VERSION }} ${{ github.event.release.prerelease && '--pre-release' || '' }}
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
           DCL_EDITOR_SDK7_SEGMENT_KEY: ${{ secrets.SEGMENT_KEY }}


### PR DESCRIPTION
Currently the CI only makes prereleases. With this change we would support making latest releases when we do a github release.