### PR TITLE
fix: use @dcl/sdk-commands instead of @dcl/sdk

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -4,7 +4,10 @@ import { npmInstall } from '../modules/npm'
 import { bin } from '../modules/bin'
 
 export async function init() {
-  const child = bin('@dcl/sdk', 'sdk-commands', ['init', '--skip-install'])
+  const child = bin('@dcl/sdk-commands', 'sdk-commands', [
+    'init',
+    '--skip-install',
+  ])
 
   await loader(
     `Creating project...`,


### PR DESCRIPTION
Use `@dcl/sdk-commands` instead of `@dcl/sdk`. This fixes the "module @dcl/sdk does not have a binary" error:

![error](https://user-images.githubusercontent.com/2781777/223516891-b7a6a4de-61c8-4453-be09-0fc37a67d91e.png)
