### PR TITLE
feat: receive console.log and console.error from scenes

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -27,7 +27,7 @@ export async function getServerUrl(server: ServerName) {
 export function getServerParams(server: ServerName) {
   switch (server) {
     case ServerName.RunScene:
-      return `?position=${encodeURI(getScene().scene.base)}`
+      return `?position=${encodeURI(getScene().scene.base)}&PIPE_CONSOLE_TO_PARENT`
     case ServerName.PublishScene:
       return getLocalValue<boolean>('isWorld') ? `?skipValidations=true` : ''
     default:

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -27,7 +27,7 @@ export async function getServerUrl(server: ServerName) {
 export function getServerParams(server: ServerName) {
   switch (server) {
     case ServerName.RunScene:
-      return `?position=${encodeURI(getScene().scene.base)}&PIPE_CONSOLE_TO_PARENT`
+      return `?position=${encodeURI(getScene().scene.base)}&PIPE_SCENE_CONSOLE`
     case ServerName.PublishScene:
       return getLocalValue<boolean>('isWorld') ? `?skipValidations=true` : ''
     default:

--- a/src/views/run-scene/webview.ts
+++ b/src/views/run-scene/webview.ts
@@ -1,5 +1,6 @@
 import path from 'path'
 import vscode from 'vscode'
+import { log } from '../../modules/log'
 import { getExtensionPath } from '../../modules/path'
 import { Webview } from '../../modules/webview'
 import { ServerName } from '../../types'
@@ -20,6 +21,15 @@ export async function createWebivew() {
   const url = await getServerUrl(ServerName.RunScene)
 
   const webview = new Webview(url, panel)
+
+  webview.onMessage((message) => {
+    if (message.type === "log" || message.type === "error") {
+      const args = message.payload as any[]
+      if (typeof args[0] === 'string' && args[0].startsWith('kernel:scene')) {
+        log(...args)
+      }
+    }
+  })
 
   return webview
 }

--- a/src/views/run-scene/webview.ts
+++ b/src/views/run-scene/webview.ts
@@ -20,14 +20,13 @@ export async function createWebivew() {
 
   const url = await getServerUrl(ServerName.RunScene)
 
-  const webview = new Webview(url, panel)
+  // TODO: make more flexible the postMessage communication or define the types on @dcl/schemas
+  // I skipped the type definition by hardly checking the message in `onMessage` function
+  const webview = new Webview<never, never, any, any>(url, panel)
 
   webview.onMessage((message) => {
-    if (message.type === "log" || message.type === "error") {
-      const args = message.payload as any[]
-      if (typeof args[0] === 'string' && args[0].startsWith('kernel:scene')) {
-        log(...args)
-      }
+    if (typeof message.type === "string" && message.type.startsWith("logger.") && message.payload && Array.isArray(message.payload.args)) {
+      log(message.type, ...message.payload.args)
     }
   })
 


### PR DESCRIPTION
# What?
Handle the messages from iframe with preview mode to enable the console.log and console.error from the scene. 

Explorer counterpart (preview mode): https://github.com/decentraland/unity-renderer/pull/4621

# Why? 
https://github.com/decentraland/sdk/issues/631