### PR TITLE
feat: notify updates in the SDK

### DIFF
--- a/src/__mocks__/vscode.ts
+++ b/src/__mocks__/vscode.ts
@@ -15,6 +15,7 @@ export const window = {
         }) => Promise<any>
       ) => onProgress({ report: jest.fn() })
     ),
+  showInformationMessage: jest.fn(),
   showWarningMessage: jest.fn(),
   showErrorMessage: jest.fn(),
   showQuickPick: jest.fn(),
@@ -36,6 +37,7 @@ export const workspace = {
 
 export const env = {
   asExternalUri: jest.fn().mockImplementation((value) => value),
+  openExternal: jest.fn(),
 }
 
 export const Uri = {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -29,6 +29,7 @@ import {
 } from './modules/analytics'
 import { activateRollbar, deactivateRollbar, report } from './modules/rollbar'
 import { getPackageJson, getPackageVersion } from './modules/pkg'
+import { notifyUpdate } from './modules/notification'
 import { getCwd, isDCL, isEmpty } from './modules/workspace'
 import { getServerUrl } from './utils'
 import { ServerName } from './types'
@@ -199,6 +200,14 @@ export async function activate(context: vscode.ExtensionContext) {
 
     // Check node binaries, download them if necessary
     await checkNodeBinaries()
+
+    // Check and notify updated version for @dcl/sdk
+    await notifyUpdate(
+      'Decentraland SDK',
+      '@dcl/sdk',
+      'sdkVersion',
+      'decentraland/js-sdk-toolchain'
+    )
 
     // Start servers and watchers
     await boot()

--- a/src/modules/notification.spec.ts
+++ b/src/modules/notification.spec.ts
@@ -1,0 +1,120 @@
+import { MessageItem, window, env, Uri } from 'vscode'
+import { notifyUpdate } from './notification'
+
+/********************************************************
+                          Mocks
+*********************************************************/
+
+import { getPackageJson } from './pkg'
+jest.mock('./pkg')
+const getPackageJsonMock = getPackageJson as jest.MockedFunction<
+  typeof getPackageJson
+>
+
+import { getGlobalValue, setGlobalValue } from './storage'
+jest.mock('./storage')
+const getGlobalValueMock = getGlobalValue as jest.MockedFunction<
+  typeof getGlobalValue
+>
+const setGlobalValueMock = setGlobalValue as jest.MockedFunction<
+  typeof setGlobalValue
+>
+
+const showInformationMessageMock =
+  window.showInformationMessage as jest.MockedFunction<
+    typeof window.showInformationMessage
+  >
+const openExternalMock = env.openExternal as jest.MockedFunction<
+  typeof env.openExternal
+>
+const uriParseMock = Uri.parse as jest.MockedFunction<typeof Uri.parse>
+
+/********************************************************
+                          Tests
+*********************************************************/
+
+describe('notification', () => {
+  describe('When the current version is 2.0.0', () => {
+    beforeEach(() => {
+      getPackageJsonMock.mockReturnValueOnce({
+        version: '2.0.0',
+        // The node engine is only necessary for the return type of the helper, not relevant for this test
+        engines: { node: '0.0.0-test' },
+      })
+    })
+    afterEach(() => {
+      getPackageJsonMock.mockReset()
+      getGlobalValueMock.mockReset()
+      setGlobalValueMock.mockReset()
+      showInformationMessageMock.mockReset()
+      openExternalMock.mockReset()
+      uriParseMock.mockReset()
+    })
+    describe('there is no previous version (first activation)', () => {
+      beforeEach(() => {
+        // The first activation will return always an undefined stored value
+        getGlobalValueMock.mockReturnValueOnce(undefined)
+      })
+      beforeEach(async () => {
+        await notifyUpdate(
+          'Test',
+          'test-module',
+          'testStorage',
+          'test-org/test-repo'
+        )
+      })
+      it('should read the current version from the package.json', () => {
+        expect(getPackageJsonMock).toHaveBeenCalledWith('test-module')
+      })
+      it('should store the current version in global storage', () => {
+        expect(setGlobalValueMock).toHaveBeenCalledWith('testStorage', '2.0.0')
+      })
+      it('should not show any notification to the user', () => {
+        expect(showInformationMessageMock).not.toHaveBeenCalled()
+      })
+    })
+    describe('and the previous version is older than the current version', () => {
+      beforeEach(() => {
+        getGlobalValueMock.mockReturnValueOnce('1.0.0')
+        showInformationMessageMock.mockResolvedValueOnce(
+          'Learn More' as unknown as MessageItem
+        )
+      })
+      beforeEach(async () => {
+        await notifyUpdate(
+          'Test',
+          'test-module',
+          'testStorage',
+          'test-org/test-repo'
+        )
+      })
+      it('should show a notification to the user', () => {
+        expect(showInformationMessageMock).toHaveBeenCalled()
+      })
+      it('should take the user to the changelog if they click on "Learn More"', () => {
+        expect(openExternalMock).toHaveBeenCalled()
+      })
+      it('should point to the changelog of the current version', () => {
+        expect(uriParseMock).toHaveBeenCalledWith(
+          'https://github.com/test-org/test-repo/releases/tag/2.0.0'
+        )
+      })
+    })
+    describe('and the previous version is the same as the current version', () => {
+      beforeEach(() => {
+        getGlobalValueMock.mockReturnValueOnce('2.0.0')
+      })
+      beforeEach(async () => {
+        await notifyUpdate(
+          'Test',
+          'test-module',
+          'testStorage',
+          'test-org/test-repo'
+        )
+      })
+      it('should not show a notification to the user', () => {
+        expect(showInformationMessageMock).not.toHaveBeenCalled()
+      })
+    })
+  })
+})

--- a/src/modules/notification.ts
+++ b/src/modules/notification.ts
@@ -1,0 +1,40 @@
+import * as vscode from 'vscode'
+import semver from 'semver'
+import { getPackageJson } from './pkg'
+import { getGlobalValue, setGlobalValue } from './storage'
+
+export async function notifyUpdate(
+  title: string,
+  moduleName: string,
+  storage: string,
+  repo: string
+) {
+  // Grab version from last activation
+  const prevVersion = getGlobalValue<string>(storage)
+
+  // Grab current versions
+  const currentVersion = getPackageJson(moduleName).version
+
+  // Update stored versions for next activation
+  setGlobalValue(storage, currentVersion)
+
+  if (!prevVersion) {
+    // No need to notify anything the first activation
+    return
+  }
+
+  // Check if the has been an upgrade in the version and notify
+  if (semver.gt(currentVersion, prevVersion)) {
+    const didClick = await vscode.window.showInformationMessage(
+      `${title} has been updated to v${currentVersion}!`,
+      `Learn More`
+    )
+    if (didClick) {
+      await vscode.env.openExternal(
+        vscode.Uri.parse(
+          `https://github.com/${repo}/releases/tag/${currentVersion}`
+        )
+      )
+    }
+  }
+}

--- a/src/modules/notification.ts
+++ b/src/modules/notification.ts
@@ -12,10 +12,10 @@ export async function notifyUpdate(
   // Grab version from last activation
   const prevVersion = getGlobalValue<string>(storage)
 
-  // Grab current versions
+  // Grab current version
   const currentVersion = getPackageJson(moduleName).version
 
-  // Update stored versions for next activation
+  // Update stored version for next activation
   setGlobalValue(storage, currentVersion)
 
   if (!prevVersion) {
@@ -23,7 +23,7 @@ export async function notifyUpdate(
     return
   }
 
-  // Check if the has been an upgrade in the version and notify
+  // Check if the version has been an updated and notify if so
   if (semver.gt(currentVersion, prevVersion)) {
     const didClick = await vscode.window.showInformationMessage(
       `${title} has been updated to v${currentVersion}!`,

--- a/src/modules/npm.spec.ts
+++ b/src/modules/npm.spec.ts
@@ -42,10 +42,9 @@ import {
 jest.mock('./analytics')
 const trackMock = track as jest.MockedFunction<typeof track>
 
-const showWarningMessagesMock =
-  window.showWarningMessage as jest.MockedFunction<
-    typeof window.showWarningMessage
-  >
+const showWarningMessageMock = window.showWarningMessage as jest.MockedFunction<
+  typeof window.showWarningMessage
+>
 
 const showErrorMessageMock = window.showErrorMessage as jest.MockedFunction<
   typeof window.showErrorMessage
@@ -225,7 +224,7 @@ describe('npm', () => {
       })
       it('should not promp the user', async () => {
         await warnOutdatedDependency('the-dependency')
-        expect(showWarningMessagesMock).not.toHaveBeenCalled()
+        expect(showWarningMessageMock).not.toHaveBeenCalled()
       })
     })
     describe('and the messagge has not been ignored', () => {
@@ -237,13 +236,13 @@ describe('npm', () => {
       })
       describe('and the user selects to update the dependency', () => {
         beforeEach(() => {
-          showWarningMessagesMock.mockResolvedValueOnce(
+          showWarningMessageMock.mockResolvedValueOnce(
             'Update' as unknown as MessageItem
           )
           loaderMock.mockResolvedValueOnce(void 0)
         })
         afterEach(() => {
-          showWarningMessagesMock.mockReset()
+          showWarningMessageMock.mockReset()
           loaderMock.mockReset()
         })
         it('should track the show event', async () => {
@@ -254,7 +253,7 @@ describe('npm', () => {
         })
         it('should promp the user', async () => {
           await warnOutdatedDependency('the-dependency')
-          expect(showWarningMessagesMock).toHaveBeenCalledWith(
+          expect(showWarningMessageMock).toHaveBeenCalledWith(
             'The dependency "the-dependency" is outdated',
             'Update',
             'Ignore'
@@ -276,13 +275,13 @@ describe('npm', () => {
       })
       describe('and the user ignores the warning', () => {
         beforeEach(() => {
-          showWarningMessagesMock.mockResolvedValueOnce(
+          showWarningMessageMock.mockResolvedValueOnce(
             'Ignore' as unknown as MessageItem
           )
           setLocalValueMock.mockReturnValueOnce(void 0)
         })
         afterEach(() => {
-          showWarningMessagesMock.mockReset()
+          showWarningMessageMock.mockReset()
           setLocalValueMock.mockReset()
         })
         it('should store the ignore flag in the local storage', async () => {


### PR DESCRIPTION
Closes https://github.com/decentraland/sdk/issues/647

This PR adds a new `notifyUpdate` helper that can be used to communicate updates of a particular module, and uses it to notify updates of the `@dcl/sdk` package. We could reuse it later if we want to track other packages, or the extension itself.