### PR TITLE
feat: pipe logs to extension output

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@dcl/inspector": "^0.1.0-4057700455.commit-453395e",
         "@dcl/schemas": "^5.18.1",
-        "@dcl/sdk": "^7.1.2",
+        "@dcl/sdk": "^7.1.3",
         "@dcl/wearable-preview": "^1.14.0",
         "@types/analytics-node": "^3.1.9",
         "@types/cmd-shim": "^5.0.0",
@@ -2332,9 +2332,9 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
     "node_modules/@dcl/dcl-rollup": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/@dcl/dcl-rollup/-/dcl-rollup-7.1.2.tgz",
-      "integrity": "sha512-YSPityJ/ANvHW1omR7m045vTtIwm1fUzi9eQvJC0WJcezl2Em2GyYBzuJyKK+TB8ExK5hB8njA0qNeYfrU/Xlw==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@dcl/dcl-rollup/-/dcl-rollup-7.1.3.tgz",
+      "integrity": "sha512-VAkq4pcefVh7PuruI+yFC6ZTLNfGDZLgHzpG+dKIwwA19Oy17P+3dhVn+//lsCGCMBUMSgQ/4gJohHMhMFzQ9w==",
       "dependencies": {
         "@rollup/plugin-commonjs": "^24.0.1",
         "@rollup/plugin-node-resolve": "^15.0.1",
@@ -2355,11 +2355,11 @@
       }
     },
     "node_modules/@dcl/ecs": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/@dcl/ecs/-/ecs-7.1.2.tgz",
-      "integrity": "sha512-EjFNXSCRY8PXmCar0xP8ikfFkTdg8W8/W4qF+v7d2+7RWC+EfWmxwEx24+6GGYDtJX/29rodC6kma2WBMUdGNg==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@dcl/ecs/-/ecs-7.1.3.tgz",
+      "integrity": "sha512-0g5qKWfUEDuWDg9PfIhJPYL0eLoKPKE6FYl7KCTBF7DKCmkVrYgLM12WQvVC9nd5KKdiJe0tsZoXkyAMWXKbcA==",
       "dependencies": {
-        "@dcl/js-runtime": "7.1.2",
+        "@dcl/js-runtime": "7.1.3",
         "@dcl/protocol": "1.0.0-4408137944.commit-a67c796"
       }
     },
@@ -2377,9 +2377,9 @@
       }
     },
     "node_modules/@dcl/explorer": {
-      "version": "1.0.90919-20230315154144.commit-30d0e51",
-      "resolved": "https://registry.npmjs.org/@dcl/explorer/-/explorer-1.0.90919-20230315154144.commit-30d0e51.tgz",
-      "integrity": "sha512-OX3UTgDHeKvaaGn/dksGbwzW1mDAjjxWnRVXgDyjb6kuKRcHhcNh0sGGIZPtFJK37P/qygWb0kugPnxA6EnmJQ=="
+      "version": "1.0.92953-20230320185045.commit-aed694a",
+      "resolved": "https://registry.npmjs.org/@dcl/explorer/-/explorer-1.0.92953-20230320185045.commit-aed694a.tgz",
+      "integrity": "sha512-nFHUbliuIXi6Vu8TQXre7MyCb1MOJGSCmtHaB80lnuFChqqucbWPPCb1ES6alpxG/30OHdh2RAOe320Cjx4N3w=="
     },
     "node_modules/@dcl/hashing": {
       "version": "1.1.3",
@@ -2493,9 +2493,9 @@
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
     },
     "node_modules/@dcl/js-runtime": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/@dcl/js-runtime/-/js-runtime-7.1.2.tgz",
-      "integrity": "sha512-oZFuso4FUrhWOo7e/RIxHxsdviy1Bsg9FFij9B80vP/3ixB0uYueCaLBgn4v+FG6NTWkDhzF/Sl7opW30OHrRQ=="
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@dcl/js-runtime/-/js-runtime-7.1.3.tgz",
+      "integrity": "sha512-4vfnGBAbdcKhsNcvVh0tBjRWu5kqemzf5kevIf3n57oil6Eac/SnZs0jVyGmLKWuBOpGOrHXFNp11VqyhF+JrQ=="
     },
     "node_modules/@dcl/kernel": {
       "version": "2.0.0-3488762509.commit-68db89b",
@@ -2553,11 +2553,11 @@
       }
     },
     "node_modules/@dcl/react-ecs": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/@dcl/react-ecs/-/react-ecs-7.1.2.tgz",
-      "integrity": "sha512-UKYJA4jKybQefqqlAc91YxTIDE2luQ1FyjNjLdLrxiF5mK+iLjeBkNeuewBaDI4HXTJU+2AZKriiqG2DJn4BNg==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@dcl/react-ecs/-/react-ecs-7.1.3.tgz",
+      "integrity": "sha512-d6VrivynIQfXeYorbcpKoCmm8ZkAYkuOvzW+b+n3nCI2O7xPsLI2BOW4NoNTaW322mr2DHa8W2DrsC5R1ifWdQ==",
       "dependencies": {
-        "@dcl/ecs": "7.1.2",
+        "@dcl/ecs": "7.1.3",
         "react": "^18.2.0",
         "react-reconciler": "^0.29.0"
       }
@@ -2616,26 +2616,26 @@
       "license": "MIT"
     },
     "node_modules/@dcl/sdk": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/@dcl/sdk/-/sdk-7.1.2.tgz",
-      "integrity": "sha512-F5Kmux8Y+i/BVP6RKFPpNn+2zNHb8ZGmDl/Ft6i6+IGSsoHE6fYLUBBJmDIR2StS65bdHx73WAZHswVhuQbcng==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@dcl/sdk/-/sdk-7.1.3.tgz",
+      "integrity": "sha512-TZhsal/bmgXJMd4+Wt/0lVWcT7vPEhXbbXVtSUahiIMp/Qc4wTVGUXjENyILAQ030sykPlelom+HN0Yzfo9gKw==",
       "dependencies": {
-        "@dcl/ecs": "7.1.2",
+        "@dcl/ecs": "7.1.3",
         "@dcl/ecs-math": "2.0.1-20221129185242.commit-40495c1",
-        "@dcl/explorer": "1.0.90919-20230315154144.commit-30d0e51",
-        "@dcl/js-runtime": "7.1.2",
-        "@dcl/react-ecs": "7.1.2",
-        "@dcl/sdk-commands": "7.1.2"
+        "@dcl/explorer": "1.0.92953-20230320185045.commit-aed694a",
+        "@dcl/js-runtime": "7.1.3",
+        "@dcl/react-ecs": "7.1.3",
+        "@dcl/sdk-commands": "7.1.3"
       }
     },
     "node_modules/@dcl/sdk-commands": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/@dcl/sdk-commands/-/sdk-commands-7.1.2.tgz",
-      "integrity": "sha512-/L640o5gqRWTkeYnyDxcV4oQ4dJWitFZ7fIqd7eZ76DylTwLf+L8X1bI72PLKuMAI+kdG7N5LVS3ty5KTiAvIw==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@dcl/sdk-commands/-/sdk-commands-7.1.3.tgz",
+      "integrity": "sha512-J+3MgUquFFhSmYgqajaw3Q6BCsuSljt3qBGrPNDQBzug4GVR0VE4It92U5Dnc+l7zQkDuWay4NVosRqirdeBjw==",
       "dependencies": {
-        "@dcl/dcl-rollup": "7.1.2",
+        "@dcl/dcl-rollup": "7.1.3",
         "@dcl/hashing": "1.1.3",
-        "@dcl/inspector": "7.1.2",
+        "@dcl/inspector": "7.1.3",
         "@dcl/linker-dapp": "0.7.0",
         "@dcl/mini-comms": "1.0.1-20230216163137.commit-a4c75be",
         "@dcl/protocol": "1.0.0-4408137944.commit-a67c796",
@@ -2663,9 +2663,9 @@
       }
     },
     "node_modules/@dcl/sdk-commands/node_modules/@dcl/inspector": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/@dcl/inspector/-/inspector-7.1.2.tgz",
-      "integrity": "sha512-3f9PaEQ9L18slYnPuHzDKTJwNWekFx2mWET6cO5H6oMtoUofA8+4cl1TmQbHZJc7cVc8y8HEz2Lw+P/zTAqrCA=="
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@dcl/inspector/-/inspector-7.1.3.tgz",
+      "integrity": "sha512-/coY2ueXu68U8L3SMUMTaX/Eyq6RVTExMsXjxPcWNoNpFtarDtRqtMoBLSr5XWsB0BGCnhdfzLS1CgK/C1w07A=="
     },
     "node_modules/@dcl/sdk-commands/node_modules/@dcl/linker-dapp": {
       "version": "0.7.0",
@@ -19719,9 +19719,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "3.19.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.19.1.tgz",
-      "integrity": "sha512-lAbrdN7neYCg/8WaoWn/ckzCtz+jr70GFfYdlf50OF7387HTg+wiuiqJRFYawwSPpqfqDNYqK7smY/ks2iAudg==",
+      "version": "3.20.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.20.0.tgz",
+      "integrity": "sha512-YsIfrk80NqUDrxrjWPXUa7PWvAfegZEXHuPsEZg58fGCdjL1I9C1i/NaG+L+27kxxwkrG/QEDEQc8s/ynXWWGQ==",
       "bin": {
         "rollup": "dist/bin/rollup"
       },

--- a/package.json
+++ b/package.json
@@ -422,7 +422,7 @@
   "dependencies": {
     "@dcl/inspector": "^0.1.0-4057700455.commit-453395e",
     "@dcl/schemas": "^5.18.1",
-    "@dcl/sdk": "^7.1.2",
+    "@dcl/sdk": "^7.1.3",
     "@dcl/wearable-preview": "^1.14.0",
     "@types/analytics-node": "^3.1.9",
     "@types/cmd-shim": "^5.0.0",

--- a/src/views/run-scene/webview.ts
+++ b/src/views/run-scene/webview.ts
@@ -25,8 +25,24 @@ export async function createWebivew() {
   const webview = new Webview<never, never, any, any>(url, panel)
 
   webview.onMessage((message) => {
-    if (typeof message.type === "string" && message.type.startsWith("logger.") && message.payload && Array.isArray(message.payload.args)) {
-      log(message.type, ...message.payload.args)
+    if (
+      typeof message.type === 'string' &&
+      message.type.startsWith('logger.') &&
+      message.payload &&
+      Array.isArray(message.payload.args)
+    ) {
+      let text = message.payload.args[3]
+      // messages of type logger.error for some reason come stringified, thus wrapped in extra double quotes
+      if (message.type === 'logger.error') {
+        try {
+          text = JSON.parse(text)
+        } catch (e) {
+          // false alarm, proceed
+        }
+      }
+      if (text) {
+        log(`scene::${message.type.split('logger.').pop()} >`, text)
+      }
     }
   })
 


### PR DESCRIPTION
This PR upgrades `@dcl/sdk` to [v7.1.3](https://github.com/decentraland/js-sdk-toolchain/releases/tag/7.1.3) and adds support for piping `console.log`s in the scene into the extension's Output tab.