### PR TITLE
fix: process leak

### DIFF
--- a/src/views/run-scene/server.ts
+++ b/src/views/run-scene/server.ts
@@ -30,7 +30,7 @@ class RunSceneServer extends Server {
       `--port ${await this.getPort()}`,
       '--no-browser',
       '--skip-install',
-      '--data-layer'
+      '--data-layer',
     ])
 
     this.child.process.on('close', async (code) => {
@@ -54,7 +54,7 @@ class RunSceneServer extends Server {
 
   async onStop() {
     if (this.child && this.child.alive()) {
-      this.child.kill()
+      await this.child.kill()
     }
   }
 }


### PR DESCRIPTION
Fixes https://github.com/decentraland/sdk/issues/677

The issue was that we were not awaiting for the `child.kill()` method to kill the `npm start` process, which internally uses the `treeKill` utility to kill all the child process spawned by the main process (in this case, it was the `sdk-commands` process spawned by the `npm start` process).

By not awaiting the promise, the `treeKill` method could not complete gathering the pids of the child processes, since that is an async procedure in some platforms (on linux it requires executing a `ps` and in mac a `pgrep`).