### PR TITLE
feat: upgrade @dcl/sdk to v7.1.13

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@dcl/inspector": "7.1.11",
         "@dcl/schemas": "^5.18.1",
-        "@dcl/sdk": "^7.1.12",
+        "@dcl/sdk": "^7.1.13",
         "@dcl/wearable-preview": "^1.14.0",
         "@types/analytics-node": "^3.1.9",
         "@types/cmd-shim": "^5.0.0",
@@ -702,11 +702,11 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
     "node_modules/@dcl/ecs": {
-      "version": "7.1.12",
-      "resolved": "https://registry.npmjs.org/@dcl/ecs/-/ecs-7.1.12.tgz",
-      "integrity": "sha512-MrKzkxtA5B09zyJHIodJTzwIAXu4RAVnVW5EmSOgGEdRJeqw5aOMAOwf5/Jb8EqwuLIXNpuK+rhyz2oaI27mGQ==",
+      "version": "7.1.13",
+      "resolved": "https://registry.npmjs.org/@dcl/ecs/-/ecs-7.1.13.tgz",
+      "integrity": "sha512-ZGobrW+n8s7G89p35+eoilasCabeC4tKV/O40FjF5ZaGW3FphslfDX5KSOaQgI2K873h9dGLKmSLTFaD6IYM3Q==",
       "dependencies": {
-        "@dcl/js-runtime": "7.1.12"
+        "@dcl/js-runtime": "7.1.13"
       }
     },
     "node_modules/@dcl/ecs-math": {
@@ -735,9 +735,9 @@
       "integrity": "sha512-qNit88wt/byo60b8tTlQrJVN5VXvRYcHg7FErIHvs2eecnOfbVFzRQvIIZVHevAt36jxYa9fAAn+ACDQdo1pWA=="
     },
     "node_modules/@dcl/js-runtime": {
-      "version": "7.1.12",
-      "resolved": "https://registry.npmjs.org/@dcl/js-runtime/-/js-runtime-7.1.12.tgz",
-      "integrity": "sha512-mqqPXuErRLYJyXwTWR7lpArEPo+rOP8dPNlXBftGUtjXcUZVG4txhKr/g+UhzLS5DDg8Rc5KRCdX0Qep9L40sg=="
+      "version": "7.1.13",
+      "resolved": "https://registry.npmjs.org/@dcl/js-runtime/-/js-runtime-7.1.13.tgz",
+      "integrity": "sha512-uFlugm4ZUmB7VeYyBbPUZ2qts5gg4RxdGSIYiFz2ogp40p9S3jdqf6tfMP3QeQr/den/TIrsJJ9iZ7lDom95ew=="
     },
     "node_modules/@dcl/kernel": {
       "version": "2.0.0-3488762509.commit-68db89b",
@@ -795,11 +795,11 @@
       }
     },
     "node_modules/@dcl/react-ecs": {
-      "version": "7.1.12",
-      "resolved": "https://registry.npmjs.org/@dcl/react-ecs/-/react-ecs-7.1.12.tgz",
-      "integrity": "sha512-UmrMw1Y0tUAk+c+3K+jF0df8b/f1kNuV/779qIqH9b+JnXukJbT2mcyWggW+1UZvBoBjXaGPrahNmDzJ1zhlfA==",
+      "version": "7.1.13",
+      "resolved": "https://registry.npmjs.org/@dcl/react-ecs/-/react-ecs-7.1.13.tgz",
+      "integrity": "sha512-v36iYwl9KTPI0pE6ADwdTpMWogygjEi5hWOEmfhPwnpPyCx2c33Ire2LYTlRaBp+Sdn/XbTL2ozTFh9lTdT2+A==",
       "dependencies": {
-        "@dcl/ecs": "7.1.12",
+        "@dcl/ecs": "7.1.13",
         "react": "^18.2.0",
         "react-reconciler": "^0.29.0"
       }
@@ -858,26 +858,26 @@
       "license": "MIT"
     },
     "node_modules/@dcl/sdk": {
-      "version": "7.1.12",
-      "resolved": "https://registry.npmjs.org/@dcl/sdk/-/sdk-7.1.12.tgz",
-      "integrity": "sha512-nQtgdEZ8a7oAGA52/nBn8DCQ09cExJ1LA1fmBg84fmRVAp6pGfYSya2dOm9Edxcl2vhY0kQi+xihbada4x4J9Q==",
+      "version": "7.1.13",
+      "resolved": "https://registry.npmjs.org/@dcl/sdk/-/sdk-7.1.13.tgz",
+      "integrity": "sha512-6Mabb2m1xy6+ZFEF8YXfFT6n44Wdn947AAmj7Gwn3+A5YbcDT1TMnPwfeSpoz6TLPudc6437ZfddOLEjEDsFKg==",
       "dependencies": {
-        "@dcl/ecs": "7.1.12",
+        "@dcl/ecs": "7.1.13",
         "@dcl/ecs-math": "2.0.1-20221129185242.commit-40495c1",
         "@dcl/explorer": "1.0.110755-20230508160103.commit-82f3587",
-        "@dcl/js-runtime": "7.1.12",
-        "@dcl/react-ecs": "7.1.12",
-        "@dcl/sdk-commands": "7.1.12"
+        "@dcl/js-runtime": "7.1.13",
+        "@dcl/react-ecs": "7.1.13",
+        "@dcl/sdk-commands": "7.1.13"
       }
     },
     "node_modules/@dcl/sdk-commands": {
-      "version": "7.1.12",
-      "resolved": "https://registry.npmjs.org/@dcl/sdk-commands/-/sdk-commands-7.1.12.tgz",
-      "integrity": "sha512-Nnxx9G3Y5IAtq5kRleDCj22eOixD14Rg5grwbp6uCG6t7Ru4hReGQ/kWpJ9tMKfQRYfffb3h6lPXykhpgz+EjQ==",
+      "version": "7.1.13",
+      "resolved": "https://registry.npmjs.org/@dcl/sdk-commands/-/sdk-commands-7.1.13.tgz",
+      "integrity": "sha512-k9reYi1YLViZsfjpy/1Jhgio8tHLSYsMrNcqe+ZcdjNXComV6sO5pJBp299RMRegmtMsA5GoT2DkmNXe2KVEqg==",
       "dependencies": {
-        "@dcl/ecs": "7.1.12",
+        "@dcl/ecs": "7.1.13",
         "@dcl/hashing": "1.1.3",
-        "@dcl/inspector": "7.1.12",
+        "@dcl/inspector": "7.1.13",
         "@dcl/linker-dapp": "0.7.0",
         "@dcl/mini-comms": "1.0.1-20230216163137.commit-a4c75be",
         "@dcl/protocol": "1.0.0-4982615619.commit-96dba07",
@@ -909,9 +909,9 @@
       }
     },
     "node_modules/@dcl/sdk-commands/node_modules/@dcl/inspector": {
-      "version": "7.1.12",
-      "resolved": "https://registry.npmjs.org/@dcl/inspector/-/inspector-7.1.12.tgz",
-      "integrity": "sha512-zGM3pqwk0ehDu1RHlfQke/9eob532LZWKLaUTUAGxRq399kmmOSkQD7uu6hN3wMINCmuNVkeHnG3e2XxaDU5SA=="
+      "version": "7.1.13",
+      "resolved": "https://registry.npmjs.org/@dcl/inspector/-/inspector-7.1.13.tgz",
+      "integrity": "sha512-oLLzAJDhWPEGgABCtOxWKwHxSOVVQD3SS5tizckhJpXHm41TloWyv/YKKjjSHJ824go+3hvQJiJ6MjZUm7Vtjw=="
     },
     "node_modules/@dcl/sdk-commands/node_modules/@dcl/linker-dapp": {
       "version": "0.7.0",
@@ -9426,9 +9426,9 @@
       }
     },
     "node_modules/path-scurry/node_modules/minipass": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-6.0.0.tgz",
-      "integrity": "sha512-mvD5U4pUen1aWcjTxUgdoMg6PB98dcV0obc/OiPzls79++IpgNoO+MCbOHRlKfWIOvjIjmjUygjZmSStP7B0Og==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-6.0.1.tgz",
+      "integrity": "sha512-Tenl5QPpgozlOGBiveNYHg2f6y+VpxsXRoIHFUVJuSmTonXRAE6q9b8Mp/O46762/2AlW4ye4Nkyvx0fgWDKbw==",
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@dcl/inspector": "7.1.11",
         "@dcl/schemas": "^5.18.1",
-        "@dcl/sdk": "7.1.11",
+        "@dcl/sdk": "^7.1.12",
         "@dcl/wearable-preview": "^1.14.0",
         "@types/analytics-node": "^3.1.9",
         "@types/cmd-shim": "^5.0.0",
@@ -702,11 +702,11 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
     "node_modules/@dcl/ecs": {
-      "version": "7.1.11",
-      "resolved": "https://registry.npmjs.org/@dcl/ecs/-/ecs-7.1.11.tgz",
-      "integrity": "sha512-AA+CLP/PIG2PJ8BVuASgQfD6peIv0sO6tQ++SdShkB5zUipMxA4Q1qybqlC5LCuU/kLrrNjkq24okxzuZrqEYA==",
+      "version": "7.1.12",
+      "resolved": "https://registry.npmjs.org/@dcl/ecs/-/ecs-7.1.12.tgz",
+      "integrity": "sha512-MrKzkxtA5B09zyJHIodJTzwIAXu4RAVnVW5EmSOgGEdRJeqw5aOMAOwf5/Jb8EqwuLIXNpuK+rhyz2oaI27mGQ==",
       "dependencies": {
-        "@dcl/js-runtime": "7.1.11"
+        "@dcl/js-runtime": "7.1.12"
       }
     },
     "node_modules/@dcl/ecs-math": {
@@ -735,9 +735,9 @@
       "integrity": "sha512-qNit88wt/byo60b8tTlQrJVN5VXvRYcHg7FErIHvs2eecnOfbVFzRQvIIZVHevAt36jxYa9fAAn+ACDQdo1pWA=="
     },
     "node_modules/@dcl/js-runtime": {
-      "version": "7.1.11",
-      "resolved": "https://registry.npmjs.org/@dcl/js-runtime/-/js-runtime-7.1.11.tgz",
-      "integrity": "sha512-jn9g7OaU17H6iU7oOYkVNYRBOe6jOZMxIrZlPioio9qMYrhz6hMan6+vp7wo6Qwmo5wyH4EQxzj4EtFuqb08BQ=="
+      "version": "7.1.12",
+      "resolved": "https://registry.npmjs.org/@dcl/js-runtime/-/js-runtime-7.1.12.tgz",
+      "integrity": "sha512-mqqPXuErRLYJyXwTWR7lpArEPo+rOP8dPNlXBftGUtjXcUZVG4txhKr/g+UhzLS5DDg8Rc5KRCdX0Qep9L40sg=="
     },
     "node_modules/@dcl/kernel": {
       "version": "2.0.0-3488762509.commit-68db89b",
@@ -795,11 +795,11 @@
       }
     },
     "node_modules/@dcl/react-ecs": {
-      "version": "7.1.11",
-      "resolved": "https://registry.npmjs.org/@dcl/react-ecs/-/react-ecs-7.1.11.tgz",
-      "integrity": "sha512-9Pr9dMfrVNC9jyGrG9FGHJRfss0iA8+E0y69zhYGMPsc8Tgkl6tqqIF1jBOJKy4jfyyt+54EKbXpD7hTTIWCaw==",
+      "version": "7.1.12",
+      "resolved": "https://registry.npmjs.org/@dcl/react-ecs/-/react-ecs-7.1.12.tgz",
+      "integrity": "sha512-UmrMw1Y0tUAk+c+3K+jF0df8b/f1kNuV/779qIqH9b+JnXukJbT2mcyWggW+1UZvBoBjXaGPrahNmDzJ1zhlfA==",
       "dependencies": {
-        "@dcl/ecs": "7.1.11",
+        "@dcl/ecs": "7.1.12",
         "react": "^18.2.0",
         "react-reconciler": "^0.29.0"
       }
@@ -858,28 +858,29 @@
       "license": "MIT"
     },
     "node_modules/@dcl/sdk": {
-      "version": "7.1.11",
-      "resolved": "https://registry.npmjs.org/@dcl/sdk/-/sdk-7.1.11.tgz",
-      "integrity": "sha512-AE5D7Z3qSZLbz55I9cY7yWW9jgV1xIjwUT6qOikxRHwE76/k6WVgUxFYkU3BaVB3QIjiwxVwNYPxwwwy7hV7rA==",
+      "version": "7.1.12",
+      "resolved": "https://registry.npmjs.org/@dcl/sdk/-/sdk-7.1.12.tgz",
+      "integrity": "sha512-nQtgdEZ8a7oAGA52/nBn8DCQ09cExJ1LA1fmBg84fmRVAp6pGfYSya2dOm9Edxcl2vhY0kQi+xihbada4x4J9Q==",
       "dependencies": {
-        "@dcl/ecs": "7.1.11",
+        "@dcl/ecs": "7.1.12",
         "@dcl/ecs-math": "2.0.1-20221129185242.commit-40495c1",
         "@dcl/explorer": "1.0.110755-20230508160103.commit-82f3587",
-        "@dcl/js-runtime": "7.1.11",
-        "@dcl/react-ecs": "7.1.11",
-        "@dcl/sdk-commands": "7.1.11"
+        "@dcl/js-runtime": "7.1.12",
+        "@dcl/react-ecs": "7.1.12",
+        "@dcl/sdk-commands": "7.1.12"
       }
     },
     "node_modules/@dcl/sdk-commands": {
-      "version": "7.1.11",
-      "resolved": "https://registry.npmjs.org/@dcl/sdk-commands/-/sdk-commands-7.1.11.tgz",
-      "integrity": "sha512-IoYXtYimhlb8/j/2V2VCI2YhewrZZNf+Rqn94DlizePxjWRfJUPvL5Y+EqQl8COCJcbeNv8q1VbCwrDz+DLb0A==",
+      "version": "7.1.12",
+      "resolved": "https://registry.npmjs.org/@dcl/sdk-commands/-/sdk-commands-7.1.12.tgz",
+      "integrity": "sha512-Nnxx9G3Y5IAtq5kRleDCj22eOixD14Rg5grwbp6uCG6t7Ru4hReGQ/kWpJ9tMKfQRYfffb3h6lPXykhpgz+EjQ==",
       "dependencies": {
+        "@dcl/ecs": "7.1.12",
         "@dcl/hashing": "1.1.3",
-        "@dcl/inspector": "7.1.11",
+        "@dcl/inspector": "7.1.12",
         "@dcl/linker-dapp": "0.7.0",
         "@dcl/mini-comms": "1.0.1-20230216163137.commit-a4c75be",
-        "@dcl/protocol": "1.0.0-4896874496.commit-2ebeae0",
+        "@dcl/protocol": "1.0.0-4982615619.commit-96dba07",
         "@dcl/rpc": "^1.1.1",
         "@dcl/schemas": "^6.11.1",
         "@segment/analytics-node": "^1.0.0-beta.22",
@@ -907,6 +908,11 @@
         "sdk-commands": "dist/index.js"
       }
     },
+    "node_modules/@dcl/sdk-commands/node_modules/@dcl/inspector": {
+      "version": "7.1.12",
+      "resolved": "https://registry.npmjs.org/@dcl/inspector/-/inspector-7.1.12.tgz",
+      "integrity": "sha512-zGM3pqwk0ehDu1RHlfQke/9eob532LZWKLaUTUAGxRq399kmmOSkQD7uu6hN3wMINCmuNVkeHnG3e2XxaDU5SA=="
+    },
     "node_modules/@dcl/sdk-commands/node_modules/@dcl/linker-dapp": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/@dcl/linker-dapp/-/linker-dapp-0.7.0.tgz",
@@ -932,11 +938,11 @@
       }
     },
     "node_modules/@dcl/sdk-commands/node_modules/@dcl/protocol": {
-      "version": "1.0.0-4896874496.commit-2ebeae0",
-      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-4896874496.commit-2ebeae0.tgz",
-      "integrity": "sha512-fiAcVqlXRX58hEO6uXbx6VX/nUAd7YjeWqcvOy0caZ7HKJPmsWl495XEoN7DxqyQuAGDYA2xQuopZVDpU6+swg==",
+      "version": "1.0.0-4982615619.commit-96dba07",
+      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-4982615619.commit-96dba07.tgz",
+      "integrity": "sha512-ILrIcd7XxREebMRkECM0RdmzwuFTi4fEvqfenoKFGfDlUJ0/jbPHGa5DjyXMOKLAK44obqgczgZjuEBTx/TLpA==",
       "dependencies": {
-        "ts-proto": "^1.146.0"
+        "@dcl/ts-proto": "^1.146.2"
       }
     },
     "node_modules/@dcl/sdk-commands/node_modules/@dcl/schemas": {
@@ -1029,9 +1035,9 @@
       }
     },
     "node_modules/@dcl/sdk-commands/node_modules/esbuild": {
-      "version": "0.17.18",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.18.tgz",
-      "integrity": "sha512-z1lix43jBs6UKjcZVKOw2xx69ffE2aG0PygLL5qJ9OS/gy0Ewd1gW/PUQIOIQGXBHWNywSc0floSKoMFF8aK2w==",
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.19.tgz",
+      "integrity": "sha512-XQ0jAPFkK/u3LcVRcvVHQcTIqD6E2H1fvZMA5dQPSOWb3suUbWbfbRf94pjc0bNzRYLfIrDRQXr7X+LHIm5oHw==",
       "hasInstallScript": true,
       "bin": {
         "esbuild": "bin/esbuild"
@@ -1040,28 +1046,28 @@
         "node": ">=12"
       },
       "optionalDependencies": {
-        "@esbuild/android-arm": "0.17.18",
-        "@esbuild/android-arm64": "0.17.18",
-        "@esbuild/android-x64": "0.17.18",
-        "@esbuild/darwin-arm64": "0.17.18",
-        "@esbuild/darwin-x64": "0.17.18",
-        "@esbuild/freebsd-arm64": "0.17.18",
-        "@esbuild/freebsd-x64": "0.17.18",
-        "@esbuild/linux-arm": "0.17.18",
-        "@esbuild/linux-arm64": "0.17.18",
-        "@esbuild/linux-ia32": "0.17.18",
-        "@esbuild/linux-loong64": "0.17.18",
-        "@esbuild/linux-mips64el": "0.17.18",
-        "@esbuild/linux-ppc64": "0.17.18",
-        "@esbuild/linux-riscv64": "0.17.18",
-        "@esbuild/linux-s390x": "0.17.18",
-        "@esbuild/linux-x64": "0.17.18",
-        "@esbuild/netbsd-x64": "0.17.18",
-        "@esbuild/openbsd-x64": "0.17.18",
-        "@esbuild/sunos-x64": "0.17.18",
-        "@esbuild/win32-arm64": "0.17.18",
-        "@esbuild/win32-ia32": "0.17.18",
-        "@esbuild/win32-x64": "0.17.18"
+        "@esbuild/android-arm": "0.17.19",
+        "@esbuild/android-arm64": "0.17.19",
+        "@esbuild/android-x64": "0.17.19",
+        "@esbuild/darwin-arm64": "0.17.19",
+        "@esbuild/darwin-x64": "0.17.19",
+        "@esbuild/freebsd-arm64": "0.17.19",
+        "@esbuild/freebsd-x64": "0.17.19",
+        "@esbuild/linux-arm": "0.17.19",
+        "@esbuild/linux-arm64": "0.17.19",
+        "@esbuild/linux-ia32": "0.17.19",
+        "@esbuild/linux-loong64": "0.17.19",
+        "@esbuild/linux-mips64el": "0.17.19",
+        "@esbuild/linux-ppc64": "0.17.19",
+        "@esbuild/linux-riscv64": "0.17.19",
+        "@esbuild/linux-s390x": "0.17.19",
+        "@esbuild/linux-x64": "0.17.19",
+        "@esbuild/netbsd-x64": "0.17.19",
+        "@esbuild/openbsd-x64": "0.17.19",
+        "@esbuild/sunos-x64": "0.17.19",
+        "@esbuild/win32-arm64": "0.17.19",
+        "@esbuild/win32-ia32": "0.17.19",
+        "@esbuild/win32-x64": "0.17.19"
       }
     },
     "node_modules/@dcl/sdk-commands/node_modules/form-data": {
@@ -1180,6 +1186,32 @@
         "uuid": "dist/bin/uuid"
       }
     },
+    "node_modules/@dcl/ts-proto": {
+      "version": "1.146.2",
+      "resolved": "https://registry.npmjs.org/@dcl/ts-proto/-/ts-proto-1.146.2.tgz",
+      "integrity": "sha512-r6iUFT+eO4/Kaafvg+vyLtq2dHkSpfehdhWd3J2mO16tcqclLjJ61CwRBXWBm31nk1L8HQFZc7iYgboMxT9g6g==",
+      "dependencies": {
+        "@types/object-hash": "^1.3.0",
+        "case-anything": "^2.1.10",
+        "dataloader": "^1.4.0",
+        "object-hash": "^1.3.1",
+        "protobufjs": "^6.11.3",
+        "ts-poet": "^6.4.1",
+        "ts-proto-descriptors": "1.9.0"
+      },
+      "bin": {
+        "protoc-gen-dcl_ts_proto": "protoc-gen-dcl_ts_proto"
+      }
+    },
+    "node_modules/@dcl/ts-proto/node_modules/ts-proto-descriptors": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/ts-proto-descriptors/-/ts-proto-descriptors-1.9.0.tgz",
+      "integrity": "sha512-Ui8zA5Q4Jnq6JIGRraUWvECrqixxtwwin8GkhIkvwCpR+JcSPsxWe8HfTj5eHfyruGYI6Zjf96XlC87hTakHfQ==",
+      "dependencies": {
+        "long": "^4.0.0",
+        "protobufjs": "^6.8.8"
+      }
+    },
     "node_modules/@dcl/unity-renderer": {
       "version": "1.0.62831-20221116134138.commit-7908797",
       "license": "Apache-2.0"
@@ -1189,9 +1221,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.17.18",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.18.tgz",
-      "integrity": "sha512-EmwL+vUBZJ7mhFCs5lA4ZimpUH3WMAoqvOIYhVQwdIgSpHC8ImHdsRyhHAVxpDYUSm0lWvd63z0XH1IlImS2Qw==",
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.19.tgz",
+      "integrity": "sha512-rIKddzqhmav7MSmoFCmDIb6e2W57geRsM94gV2l38fzhXMwq7hZoClug9USI2pFRGL06f4IOPHHpFNOkWieR8A==",
       "cpu": [
         "arm"
       ],
@@ -1204,9 +1236,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.17.18",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.17.18.tgz",
-      "integrity": "sha512-/iq0aK0eeHgSC3z55ucMAHO05OIqmQehiGay8eP5l/5l+iEr4EIbh4/MI8xD9qRFjqzgkc0JkX0LculNC9mXBw==",
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.17.19.tgz",
+      "integrity": "sha512-KBMWvEZooR7+kzY0BtbTQn0OAYY7CsiydT63pVEaPtVYF0hXbUaOyZog37DKxK7NF3XacBJOpYT4adIJh+avxA==",
       "cpu": [
         "arm64"
       ],
@@ -1219,9 +1251,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.17.18",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.17.18.tgz",
-      "integrity": "sha512-x+0efYNBF3NPW2Xc5bFOSFW7tTXdAcpfEg2nXmxegm4mJuVeS+i109m/7HMiOQ6M12aVGGFlqJX3RhNdYM2lWg==",
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.17.19.tgz",
+      "integrity": "sha512-uUTTc4xGNDT7YSArp/zbtmbhO0uEEK9/ETW29Wk1thYUJBz3IVnvgEiEwEa9IeLyvnpKrWK64Utw2bgUmDveww==",
       "cpu": [
         "x64"
       ],
@@ -1234,9 +1266,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.17.18",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.18.tgz",
-      "integrity": "sha512-6tY+djEAdF48M1ONWnQb1C+6LiXrKjmqjzPNPWXhu/GzOHTHX2nh8Mo2ZAmBFg0kIodHhciEgUBtcYCAIjGbjQ==",
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.19.tgz",
+      "integrity": "sha512-80wEoCfF/hFKM6WE1FyBHc9SfUblloAWx6FJkFWTWiCoht9Mc0ARGEM47e67W9rI09YoUxJL68WHfDRYEAvOhg==",
       "cpu": [
         "arm64"
       ],
@@ -1249,9 +1281,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.17.18",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.18.tgz",
-      "integrity": "sha512-Qq84ykvLvya3dO49wVC9FFCNUfSrQJLbxhoQk/TE1r6MjHo3sFF2tlJCwMjhkBVq3/ahUisj7+EpRSz0/+8+9A==",
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.19.tgz",
+      "integrity": "sha512-IJM4JJsLhRYr9xdtLytPLSH9k/oxR3boaUIYiHkAawtwNOXKE8KoU8tMvryogdcT8AU+Bflmh81Xn6Q0vTZbQw==",
       "cpu": [
         "x64"
       ],
@@ -1264,9 +1296,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.17.18",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.18.tgz",
-      "integrity": "sha512-fw/ZfxfAzuHfaQeMDhbzxp9mc+mHn1Y94VDHFHjGvt2Uxl10mT4CDavHm+/L9KG441t1QdABqkVYwakMUeyLRA==",
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.19.tgz",
+      "integrity": "sha512-pBwbc7DufluUeGdjSU5Si+P3SoMF5DQ/F/UmTSb8HXO80ZEAJmrykPyzo1IfNbAoaqw48YRpv8shwd1NoI0jcQ==",
       "cpu": [
         "arm64"
       ],
@@ -1279,9 +1311,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.17.18",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.17.18.tgz",
-      "integrity": "sha512-FQFbRtTaEi8ZBi/A6kxOC0V0E9B/97vPdYjY9NdawyLd4Qk5VD5g2pbWN2VR1c0xhzcJm74HWpObPszWC+qTew==",
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.17.19.tgz",
+      "integrity": "sha512-4lu+n8Wk0XlajEhbEffdy2xy53dpR06SlzvhGByyg36qJw6Kpfk7cp45DR/62aPH9mtJRmIyrXAS5UWBrJT6TQ==",
       "cpu": [
         "x64"
       ],
@@ -1294,9 +1326,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.17.18",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.17.18.tgz",
-      "integrity": "sha512-jW+UCM40LzHcouIaqv3e/oRs0JM76JfhHjCavPxMUti7VAPh8CaGSlS7cmyrdpzSk7A+8f0hiedHqr/LMnfijg==",
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.17.19.tgz",
+      "integrity": "sha512-cdmT3KxjlOQ/gZ2cjfrQOtmhG4HJs6hhvm3mWSRDPtZ/lP5oe8FWceS10JaSJC13GBd4eH/haHnqf7hhGNLerA==",
       "cpu": [
         "arm"
       ],
@@ -1309,9 +1341,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.17.18",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.17.18.tgz",
-      "integrity": "sha512-R7pZvQZFOY2sxUG8P6A21eq6q+eBv7JPQYIybHVf1XkQYC+lT7nDBdC7wWKTrbvMXKRaGudp/dzZCwL/863mZQ==",
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.17.19.tgz",
+      "integrity": "sha512-ct1Tg3WGwd3P+oZYqic+YZF4snNl2bsnMKRkb3ozHmnM0dGWuxcPTTntAF6bOP0Sp4x0PjSF+4uHQ1xvxfRKqg==",
       "cpu": [
         "arm64"
       ],
@@ -1324,9 +1356,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.17.18",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.17.18.tgz",
-      "integrity": "sha512-ygIMc3I7wxgXIxk6j3V00VlABIjq260i967Cp9BNAk5pOOpIXmd1RFQJQX9Io7KRsthDrQYrtcx7QCof4o3ZoQ==",
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.17.19.tgz",
+      "integrity": "sha512-w4IRhSy1VbsNxHRQpeGCHEmibqdTUx61Vc38APcsRbuVgK0OPEnQ0YD39Brymn96mOx48Y2laBQGqgZ0j9w6SQ==",
       "cpu": [
         "ia32"
       ],
@@ -1339,9 +1371,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.17.18",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.17.18.tgz",
-      "integrity": "sha512-bvPG+MyFs5ZlwYclCG1D744oHk1Pv7j8psF5TfYx7otCVmcJsEXgFEhQkbhNW8otDHL1a2KDINW20cfCgnzgMQ==",
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.17.19.tgz",
+      "integrity": "sha512-2iAngUbBPMq439a+z//gE+9WBldoMp1s5GWsUSgqHLzLJ9WoZLZhpwWuym0u0u/4XmZ3gpHmzV84PonE+9IIdQ==",
       "cpu": [
         "loong64"
       ],
@@ -1354,9 +1386,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.17.18",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.17.18.tgz",
-      "integrity": "sha512-oVqckATOAGuiUOa6wr8TXaVPSa+6IwVJrGidmNZS1cZVx0HqkTMkqFGD2HIx9H1RvOwFeWYdaYbdY6B89KUMxA==",
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.17.19.tgz",
+      "integrity": "sha512-LKJltc4LVdMKHsrFe4MGNPp0hqDFA1Wpt3jE1gEyM3nKUvOiO//9PheZZHfYRfYl6AwdTH4aTcXSqBerX0ml4A==",
       "cpu": [
         "mips64el"
       ],
@@ -1369,9 +1401,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.17.18",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.17.18.tgz",
-      "integrity": "sha512-3dLlQO+b/LnQNxgH4l9rqa2/IwRJVN9u/bK63FhOPB4xqiRqlQAU0qDU3JJuf0BmaH0yytTBdoSBHrb2jqc5qQ==",
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.17.19.tgz",
+      "integrity": "sha512-/c/DGybs95WXNS8y3Ti/ytqETiW7EU44MEKuCAcpPto3YjQbyK3IQVKfF6nbghD7EcLUGl0NbiL5Rt5DMhn5tg==",
       "cpu": [
         "ppc64"
       ],
@@ -1384,9 +1416,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.17.18",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.17.18.tgz",
-      "integrity": "sha512-/x7leOyDPjZV3TcsdfrSI107zItVnsX1q2nho7hbbQoKnmoeUWjs+08rKKt4AUXju7+3aRZSsKrJtaRmsdL1xA==",
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.17.19.tgz",
+      "integrity": "sha512-FC3nUAWhvFoutlhAkgHf8f5HwFWUL6bYdvLc/TTuxKlvLi3+pPzdZiFKSWz/PF30TB1K19SuCxDTI5KcqASJqA==",
       "cpu": [
         "riscv64"
       ],
@@ -1399,9 +1431,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.17.18",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.17.18.tgz",
-      "integrity": "sha512-cX0I8Q9xQkL/6F5zWdYmVf5JSQt+ZfZD2bJudZrWD+4mnUvoZ3TDDXtDX2mUaq6upMFv9FlfIh4Gfun0tbGzuw==",
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.17.19.tgz",
+      "integrity": "sha512-IbFsFbxMWLuKEbH+7sTkKzL6NJmG2vRyy6K7JJo55w+8xDk7RElYn6xvXtDW8HCfoKBFK69f3pgBJSUSQPr+4Q==",
       "cpu": [
         "s390x"
       ],
@@ -1414,9 +1446,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.17.18",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.17.18.tgz",
-      "integrity": "sha512-66RmRsPlYy4jFl0vG80GcNRdirx4nVWAzJmXkevgphP1qf4dsLQCpSKGM3DUQCojwU1hnepI63gNZdrr02wHUA==",
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.17.19.tgz",
+      "integrity": "sha512-68ngA9lg2H6zkZcyp22tsVt38mlhWde8l3eJLWkyLrp4HwMUr3c1s/M2t7+kHIhvMjglIBrFpncX1SzMckomGw==",
       "cpu": [
         "x64"
       ],
@@ -1429,9 +1461,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.17.18",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.18.tgz",
-      "integrity": "sha512-95IRY7mI2yrkLlTLb1gpDxdC5WLC5mZDi+kA9dmM5XAGxCME0F8i4bYH4jZreaJ6lIZ0B8hTrweqG1fUyW7jbg==",
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.19.tgz",
+      "integrity": "sha512-CwFq42rXCR8TYIjIfpXCbRX0rp1jo6cPIUPSaWwzbVI4aOfX96OXY8M6KNmtPcg7QjYeDmN+DD0Wp3LaBOLf4Q==",
       "cpu": [
         "x64"
       ],
@@ -1444,9 +1476,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.17.18",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.18.tgz",
-      "integrity": "sha512-WevVOgcng+8hSZ4Q3BKL3n1xTv5H6Nb53cBrtzzEjDbbnOmucEVcZeGCsCOi9bAOcDYEeBZbD2SJNBxlfP3qiA==",
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.19.tgz",
+      "integrity": "sha512-cnq5brJYrSZ2CF6c35eCmviIN3k3RczmHz8eYaVlNasVqsNY+JKohZU5MKmaOI+KkllCdzOKKdPs762VCPC20g==",
       "cpu": [
         "x64"
       ],
@@ -1459,9 +1491,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.17.18",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.17.18.tgz",
-      "integrity": "sha512-Rzf4QfQagnwhQXVBS3BYUlxmEbcV7MY+BH5vfDZekU5eYpcffHSyjU8T0xucKVuOcdCsMo+Ur5wmgQJH2GfNrg==",
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.17.19.tgz",
+      "integrity": "sha512-vCRT7yP3zX+bKWFeP/zdS6SqdWB8OIpaRq/mbXQxTGHnIxspRtigpkUcDMlSCOejlHowLqII7K2JKevwyRP2rg==",
       "cpu": [
         "x64"
       ],
@@ -1474,9 +1506,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.17.18",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.17.18.tgz",
-      "integrity": "sha512-Kb3Ko/KKaWhjeAm2YoT/cNZaHaD1Yk/pa3FTsmqo9uFh1D1Rfco7BBLIPdDOozrObj2sahslFuAQGvWbgWldAg==",
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.17.19.tgz",
+      "integrity": "sha512-yYx+8jwowUstVdorcMdNlzklLYhPxjniHWFKgRqH7IFlUEa0Umu3KuYplf1HUZZ422e3NU9F4LGb+4O0Kdcaag==",
       "cpu": [
         "arm64"
       ],
@@ -1489,9 +1521,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.17.18",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.17.18.tgz",
-      "integrity": "sha512-0/xUMIdkVHwkvxfbd5+lfG7mHOf2FRrxNbPiKWg9C4fFrB8H0guClmaM3BFiRUYrznVoyxTIyC/Ou2B7QQSwmw==",
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.17.19.tgz",
+      "integrity": "sha512-eggDKanJszUtCdlVs0RB+h35wNlb5v4TWEkq4vZcmVt5u/HiDZrTXe2bWFQUez3RgNHwx/x4sk5++4NSSicKkw==",
       "cpu": [
         "ia32"
       ],
@@ -1504,9 +1536,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.17.18",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.17.18.tgz",
-      "integrity": "sha512-qU25Ma1I3NqTSHJUOKi9sAH1/Mzuvlke0ioMJRthLXKm7JiSKVwFghlGbDLOO2sARECGhja4xYfRAZNPAkooYg==",
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.17.19.tgz",
+      "integrity": "sha512-lAhycmKnVOuRYNtRtatQR1LPQf2oYCkRGkSFnseDAKPl8lu5SOsK/e1sXe5a0Pc5kHIHe6P2I/ilntNv2xf3cA==",
       "cpu": [
         "x64"
       ],
@@ -9371,12 +9403,12 @@
       "license": "MIT"
     },
     "node_modules/path-scurry": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.8.0.tgz",
-      "integrity": "sha512-IjTrKseM404/UAWA8bBbL3Qp6O2wXkanuIE3seCxBH7ctRuvH1QRawy1N3nVDHGkdeZsjOsSe/8AQBL/VQCy2g==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.9.1.tgz",
+      "integrity": "sha512-UgmoiySyjFxP6tscZDgWGEAgsW5ok8W3F5CJDnnH2pozwSTGE6eH7vwTotMwATWA2r5xqdkKdxYPkwlJjAI/3g==",
       "dependencies": {
         "lru-cache": "^9.1.1",
-        "minipass": "^5.0.0"
+        "minipass": "^5.0.0 || ^6.0.0"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -9394,11 +9426,11 @@
       }
     },
     "node_modules/path-scurry/node_modules/minipass": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-6.0.0.tgz",
+      "integrity": "sha512-mvD5U4pUen1aWcjTxUgdoMg6PB98dcV0obc/OiPzls79++IpgNoO+MCbOHRlKfWIOvjIjmjUygjZmSStP7B0Og==",
       "engines": {
-        "node": ">=8"
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/path-to-regexp": {

--- a/package.json
+++ b/package.json
@@ -422,7 +422,7 @@
   "dependencies": {
     "@dcl/inspector": "7.1.11",
     "@dcl/schemas": "^5.18.1",
-    "@dcl/sdk": "7.1.11",
+    "@dcl/sdk": "^7.1.12",
     "@dcl/wearable-preview": "^1.14.0",
     "@types/analytics-node": "^3.1.9",
     "@types/cmd-shim": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -422,7 +422,7 @@
   "dependencies": {
     "@dcl/inspector": "7.1.11",
     "@dcl/schemas": "^5.18.1",
-    "@dcl/sdk": "^7.1.12",
+    "@dcl/sdk": "^7.1.13",
     "@dcl/wearable-preview": "^1.14.0",
     "@types/analytics-node": "^3.1.9",
     "@types/cmd-shim": "^5.0.0",

--- a/src/modules/sdk.ts
+++ b/src/modules/sdk.ts
@@ -1,3 +1,4 @@
+import semver from 'semver'
 import { log } from './log'
 import { npmInstall } from './npm'
 import { getPackageVersion } from './pkg'
@@ -9,11 +10,11 @@ export async function syncSdkVersion() {
     // no need to sync if the workspace does not have a dependency on @dcl/sdk
     return
   }
-  if (extensionSdkVersion !== workspaceSdkVersion) {
+  if (semver.lt(workspaceSdkVersion, extensionSdkVersion!)) {
     log(`Extension @dcl/sdk version: ${extensionSdkVersion}`)
     log(`Workspace @dcl/sdk version: ${workspaceSdkVersion}`)
     log(
-      `Workspace @dcl/sdk version is different than the extension\'s, installing @dcl/sdk@${extensionSdkVersion} into workspace...`
+      `Workspace @dcl/sdk version is older than the extension\'s, installing @dcl/sdk@${extensionSdkVersion} into workspace...`
     )
     await npmInstall(`@dcl/sdk@${extensionSdkVersion}`)
   }

--- a/src/views/inspector/server.ts
+++ b/src/views/inspector/server.ts
@@ -2,7 +2,12 @@ import path from 'path'
 import { StaticServer } from '../../modules/server'
 import { ServerName } from '../../types'
 import { getCwd } from '../../modules/workspace'
+import { log } from '../../modules/log'
 
-export const inspectorServer = new StaticServer(ServerName.Inspector, () =>
-  path.join(getCwd(), './node_modules/@dcl/inspector/public')
-)
+export const inspectorServer = new StaticServer(ServerName.Inspector, () => {
+  const inspectorPath = path.dirname(
+    require.resolve('@dcl/inspector/package.json', { paths: [getCwd()] })
+  )
+  log('Serving inspector from:', inspectorPath)
+  return path.join(inspectorPath, './public')
+})

--- a/src/views/inspector/server.ts
+++ b/src/views/inspector/server.ts
@@ -1,8 +1,8 @@
 import path from 'path'
-import { getExtensionPath } from '../../modules/path'
 import { StaticServer } from '../../modules/server'
 import { ServerName } from '../../types'
+import { getCwd } from '../../modules/workspace'
 
 export const inspectorServer = new StaticServer(ServerName.Inspector, () =>
-  path.join(getExtensionPath(), './node_modules/@dcl/inspector/public')
+  path.join(getCwd(), './node_modules/@dcl/inspector/public')
 )

--- a/src/views/inspector/webview.ts
+++ b/src/views/inspector/webview.ts
@@ -22,7 +22,7 @@ export async function createWebview() {
   dataLayerUrl.pathname = '/data-layer'
   dataLayerUrl.search = ''
   dataLayerUrl.protocol = 'ws:'
-  const dataLayerRpcWsUrl = dataLayerUrl.toString() 
+  const dataLayerRpcWsUrl = dataLayerUrl.toString()
 
   const url = await getServerUrl(ServerName.Inspector)
   await waitForServer(url)
@@ -30,11 +30,14 @@ export async function createWebview() {
   const html = await fetch(url).then((res) => res.text())
 
   const config = {
-    dataLayerRpcWsUrl: dataLayerRpcWsUrl
+    dataLayerRpcWsUrl: dataLayerRpcWsUrl,
   }
-  
+
   panel.webview.html = html
     .replace('bundle.js', `${url}/bundle.js`)
     .replace('bundle.css', `${url}/bundle.css`)
-    .replace(/(const config = ')(\$CONFIG)(')/gi, `$1${JSON.stringify(config)}$3`)
+    .replace(
+      /(const config = ')(\$CONFIG)(')/gi,
+      `$1${JSON.stringify(config)}$3`
+    )
 }


### PR DESCRIPTION
Upgrade `@dcl/sdk` to `v7.1.13`, also fixed issue where `@next` version of the sdk installed in the workspace would be downgraded to `@latest`, and made the `@dcl/inspector` to be served from the workspace's `node_modules`