### PR TITLE
feat: add support for smart items

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@dcl/inspector": "7.3.4",
         "@dcl/schemas": "^5.18.1",
-        "@dcl/sdk": "7.3.19",
+        "@dcl/sdk": "7.3.20",
         "@dcl/wearable-preview": "^1.14.0",
         "@sentry/node": "^7.64.0",
         "@types/analytics-node": "^3.1.9",
@@ -630,9 +630,9 @@
       "license": "MIT"
     },
     "node_modules/@dcl/asset-packs": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@dcl/asset-packs/-/asset-packs-1.2.1.tgz",
-      "integrity": "sha512-aNUGZnpyS8wS9MEhwoU22GU8SL3EQOEB8z5QtbeJBIFR4BcjY8HRu+UAXULNyaxpy+ddL/qACSuSAD59HgBk2g==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@dcl/asset-packs/-/asset-packs-1.2.3.tgz",
+      "integrity": "sha512-gjyWSNpjSY4ddYLExAbEiiD5copAl4Qfi8PuYmxr9i2XvWe4SXWtwIgRWlAEhBv1dFKsOfMOw+TXKXM7kApwBg==",
       "dependencies": {
         "@dcl-sdk/utils": "^1.1.3",
         "@dcl/js-runtime": "7.3.18",
@@ -723,9 +723,9 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
     "node_modules/@dcl/ecs": {
-      "version": "7.3.19",
-      "resolved": "https://registry.npmjs.org/@dcl/ecs/-/ecs-7.3.19.tgz",
-      "integrity": "sha512-lQsIz7jvGTqiiZMoO0fu0oXrKCStlwokb51M/yx0/jlVyjP7jVL7CzVtfbSYNpau2lip5kBVKnLeUb4glVO6Dw=="
+      "version": "7.3.20",
+      "resolved": "https://registry.npmjs.org/@dcl/ecs/-/ecs-7.3.20.tgz",
+      "integrity": "sha512-dcHjyGP+L1ZRD1AcEvZ8FsLE3mQLDVpPUSJe4rd0OS0ROF1/gAlBA14FCiNJckK0x1ccE6lLSKXsThwJkDfghg=="
     },
     "node_modules/@dcl/ecs-math": {
       "version": "2.0.2",
@@ -733,9 +733,9 @@
       "integrity": "sha512-w01+a3mpHvxGPHepu0hAAX8OfpBSQEqBbC1+U8o+5SBSQVXHiRwt3P4cK20yM8QCgZe3enPttmpqePnjTliTig=="
     },
     "node_modules/@dcl/explorer": {
-      "version": "1.0.148846-20231002132009.commit-60a8fe3",
-      "resolved": "https://registry.npmjs.org/@dcl/explorer/-/explorer-1.0.148846-20231002132009.commit-60a8fe3.tgz",
-      "integrity": "sha512-en65I+qBqfV7cvFE671qe9N9zu6ZZ8C5uqV6wVgsgd6ods9jaTx0cgd4s1FxGHTY2WYdBd1fHVNRlvcxHhKtmA=="
+      "version": "1.0.150826-20231009190521.commit-9698dfc",
+      "resolved": "https://registry.npmjs.org/@dcl/explorer/-/explorer-1.0.150826-20231009190521.commit-9698dfc.tgz",
+      "integrity": "sha512-B2jWNDz8nnt/2EkRXPDji4A8KT+zljWSmLnQnPG/zQ8PaBbPIHdn9XvxqrEvU7BnofdKyP/R+sODkao9333Bbw=="
     },
     "node_modules/@dcl/hashing": {
       "version": "1.1.3",
@@ -753,9 +753,9 @@
       "integrity": "sha512-CPtVM5L8xh6cgd8O/rvKZnloeMn9Gfp55G+uaFboKWPO7OazpZOc9yVQWlXODDPWFWPCktmD41zXTBHrXk/RBQ=="
     },
     "node_modules/@dcl/js-runtime": {
-      "version": "7.3.19",
-      "resolved": "https://registry.npmjs.org/@dcl/js-runtime/-/js-runtime-7.3.19.tgz",
-      "integrity": "sha512-xCYRm6Hnr2m6ukRVFBCmOpnnpeWewpMgVg99/THiWbOy6lAhVs4yRVGmnb4QduhOHlUleZUPsF+/lli4OPkK/g=="
+      "version": "7.3.20",
+      "resolved": "https://registry.npmjs.org/@dcl/js-runtime/-/js-runtime-7.3.20.tgz",
+      "integrity": "sha512-qVHdikkowzmHBgaapDfslAmB190nyphO5bNUf5jCwnt4fM06+AEmbqev7iQ5kBt/DLCLFNrM4vfJxWgkiYWOAg=="
     },
     "node_modules/@dcl/kernel": {
       "version": "2.0.0-3488762509.commit-68db89b",
@@ -818,11 +818,11 @@
       "integrity": "sha512-4iSvVQdiR558XDcnUvQPvuGfaGa0CK2mRac8RnAQeW1k45JkOPWiVv8cv6LT6bF5IcuksK0LkQIVG252eF1VRw=="
     },
     "node_modules/@dcl/react-ecs": {
-      "version": "7.3.19",
-      "resolved": "https://registry.npmjs.org/@dcl/react-ecs/-/react-ecs-7.3.19.tgz",
-      "integrity": "sha512-loNPYPi1fqq8W0r1PdcCo/Vy6sBWdrF8PVCP44V23T5E3XAJsHD18C7c42KhQdbxiTM8Xssr1qSAAQJiqM05dA==",
+      "version": "7.3.20",
+      "resolved": "https://registry.npmjs.org/@dcl/react-ecs/-/react-ecs-7.3.20.tgz",
+      "integrity": "sha512-Id7vvirDHujdinVccvCeu6vx5XnwMDdhNhiaIWjQwgPX0I91DwdW8ldsIvfr5fcwawfjS/6ZMfzBMduo7HNNcA==",
       "dependencies": {
-        "@dcl/ecs": "7.3.19",
+        "@dcl/ecs": "7.3.20",
         "react": "^18.2.0",
         "react-reconciler": "^0.29.0"
       }
@@ -881,27 +881,27 @@
       "license": "MIT"
     },
     "node_modules/@dcl/sdk": {
-      "version": "7.3.19",
-      "resolved": "https://registry.npmjs.org/@dcl/sdk/-/sdk-7.3.19.tgz",
-      "integrity": "sha512-loL+2FqhvNTQgzc53ao3mMH3h/UzPQ/M1XUQSEeKRnsNt9krAw2OiDR2fLs1INa5n0pP9HjqWVCmEiFaW8OtbQ==",
+      "version": "7.3.20",
+      "resolved": "https://registry.npmjs.org/@dcl/sdk/-/sdk-7.3.20.tgz",
+      "integrity": "sha512-sAVRQK4z42PPOF8m//U70zVDw5Rt5YyQ5VoQJ6NKqqqCdg6l7/ubgCLY5dvrqW9g4tDgpa21+RyCDP4w0WcKYA==",
       "dependencies": {
-        "@dcl/ecs": "7.3.19",
+        "@dcl/ecs": "7.3.20",
         "@dcl/ecs-math": "2.0.2",
-        "@dcl/explorer": "1.0.148846-20231002132009.commit-60a8fe3",
-        "@dcl/js-runtime": "7.3.19",
-        "@dcl/react-ecs": "7.3.19",
-        "@dcl/sdk-commands": "7.3.19"
+        "@dcl/explorer": "1.0.150826-20231009190521.commit-9698dfc",
+        "@dcl/js-runtime": "7.3.20",
+        "@dcl/react-ecs": "7.3.20",
+        "@dcl/sdk-commands": "7.3.20"
       }
     },
     "node_modules/@dcl/sdk-commands": {
-      "version": "7.3.19",
-      "resolved": "https://registry.npmjs.org/@dcl/sdk-commands/-/sdk-commands-7.3.19.tgz",
-      "integrity": "sha512-8bofuDGtK5uJ9H+Gw4DnU2k4ZGrLArHyI6J63iPMU5mT7lQenLRB8/Q92xrtre1qIsjzB5azg56xiTNsXoKiLg==",
+      "version": "7.3.20",
+      "resolved": "https://registry.npmjs.org/@dcl/sdk-commands/-/sdk-commands-7.3.20.tgz",
+      "integrity": "sha512-LqD7vtXSdpHaMHWIPw1KZuY2wErzD8e6KT9nvdRh4jpIgRkYyh5pC5PgmyqB5SPHAbHNV9XRXHHdiCOGiHPcSA==",
       "dependencies": {
         "@dcl/crypto": "^3.4.4",
-        "@dcl/ecs": "7.3.19",
+        "@dcl/ecs": "7.3.20",
         "@dcl/hashing": "1.1.3",
-        "@dcl/inspector": "7.3.19",
+        "@dcl/inspector": "7.3.20",
         "@dcl/linker-dapp": "^0.11.0",
         "@dcl/mini-comms": "1.0.1-20230216163137.commit-a4c75be",
         "@dcl/protocol": "1.0.0-6314457636.commit-a9a962a",
@@ -942,11 +942,11 @@
       "integrity": "sha512-4xRIlrXTrUIZEf/TmZY4xiF7ZC1ixJJvCwEct1Xtyt3hrqVpfetuuzgBfKOvsy4kUu2syJ3hI8QL/vPO5CigcA=="
     },
     "node_modules/@dcl/sdk-commands/node_modules/@dcl/inspector": {
-      "version": "7.3.19",
-      "resolved": "https://registry.npmjs.org/@dcl/inspector/-/inspector-7.3.19.tgz",
-      "integrity": "sha512-BNkNmwUAVVDU7OevKNSN1dzrhWWvx64KmYmp/qJAoAnjznMQGd6avrq7oyXmp59S+2K+1Rdvj2y/5BoUMnrayg==",
+      "version": "7.3.20",
+      "resolved": "https://registry.npmjs.org/@dcl/inspector/-/inspector-7.3.20.tgz",
+      "integrity": "sha512-QxTBC+aBET5jw+bJvULjLw6WbVEHAgp/DfeFZ/JUCLJ/Y8uP/ZVzr8XgY4kBF0BEfT76CGu0K0h21k76xhbR5g==",
       "dependencies": {
-        "@dcl/asset-packs": "^1.2.1"
+        "@dcl/asset-packs": "^1.2.3"
       }
     },
     "node_modules/@dcl/sdk-commands/node_modules/@dcl/linker-dapp": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@dcl/inspector": "7.3.4",
         "@dcl/schemas": "^5.18.1",
-        "@dcl/sdk": "7.3.18",
+        "@dcl/sdk": "7.3.19",
         "@dcl/wearable-preview": "^1.14.0",
         "@sentry/node": "^7.64.0",
         "@types/analytics-node": "^3.1.9",
@@ -620,9 +620,30 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "node_modules/@dcl-sdk/utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@dcl-sdk/utils/-/utils-1.1.3.tgz",
+      "integrity": "sha512-zA3Q+O+fW1U4soYcTAxYr3ASD8Rl555hHoUF2cAJBbM73fd2G2wDUGnCjZCsq56wbOXMIIZqw1ynKy6Q/yQAZQ=="
+    },
     "node_modules/@dcl/amd": {
       "version": "6.11.11",
       "license": "MIT"
+    },
+    "node_modules/@dcl/asset-packs": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@dcl/asset-packs/-/asset-packs-1.2.1.tgz",
+      "integrity": "sha512-aNUGZnpyS8wS9MEhwoU22GU8SL3EQOEB8z5QtbeJBIFR4BcjY8HRu+UAXULNyaxpy+ddL/qACSuSAD59HgBk2g==",
+      "dependencies": {
+        "@dcl-sdk/utils": "^1.1.3",
+        "@dcl/js-runtime": "7.3.18",
+        "@dcl/sdk": "^7.3.18",
+        "mitt": "^3.0.1"
+      }
+    },
+    "node_modules/@dcl/asset-packs/node_modules/@dcl/js-runtime": {
+      "version": "7.3.18",
+      "resolved": "https://registry.npmjs.org/@dcl/js-runtime/-/js-runtime-7.3.18.tgz",
+      "integrity": "sha512-kdcjyIdS2jgklZpFKGhy3PWecDpng9u7Goyn8ek4JLtBxYtD35F9yb5mSAflnayoyy8M2lQwRbW7gDZF8n7DYw=="
     },
     "node_modules/@dcl/build-ecs": {
       "version": "6.11.11",
@@ -702,9 +723,9 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
     "node_modules/@dcl/ecs": {
-      "version": "7.3.18",
-      "resolved": "https://registry.npmjs.org/@dcl/ecs/-/ecs-7.3.18.tgz",
-      "integrity": "sha512-J3BOeAFwcYmwpOv2akphYUNq+rfwHTzEgU5/NENy3eQrsyU2TyQaiCWGQpdfOeKLyJIIpcBjKpzL3GM3Amf+Rg=="
+      "version": "7.3.19",
+      "resolved": "https://registry.npmjs.org/@dcl/ecs/-/ecs-7.3.19.tgz",
+      "integrity": "sha512-lQsIz7jvGTqiiZMoO0fu0oXrKCStlwokb51M/yx0/jlVyjP7jVL7CzVtfbSYNpau2lip5kBVKnLeUb4glVO6Dw=="
     },
     "node_modules/@dcl/ecs-math": {
       "version": "2.0.2",
@@ -732,9 +753,9 @@
       "integrity": "sha512-CPtVM5L8xh6cgd8O/rvKZnloeMn9Gfp55G+uaFboKWPO7OazpZOc9yVQWlXODDPWFWPCktmD41zXTBHrXk/RBQ=="
     },
     "node_modules/@dcl/js-runtime": {
-      "version": "7.3.18",
-      "resolved": "https://registry.npmjs.org/@dcl/js-runtime/-/js-runtime-7.3.18.tgz",
-      "integrity": "sha512-kdcjyIdS2jgklZpFKGhy3PWecDpng9u7Goyn8ek4JLtBxYtD35F9yb5mSAflnayoyy8M2lQwRbW7gDZF8n7DYw=="
+      "version": "7.3.19",
+      "resolved": "https://registry.npmjs.org/@dcl/js-runtime/-/js-runtime-7.3.19.tgz",
+      "integrity": "sha512-xCYRm6Hnr2m6ukRVFBCmOpnnpeWewpMgVg99/THiWbOy6lAhVs4yRVGmnb4QduhOHlUleZUPsF+/lli4OPkK/g=="
     },
     "node_modules/@dcl/kernel": {
       "version": "2.0.0-3488762509.commit-68db89b",
@@ -797,11 +818,11 @@
       "integrity": "sha512-4iSvVQdiR558XDcnUvQPvuGfaGa0CK2mRac8RnAQeW1k45JkOPWiVv8cv6LT6bF5IcuksK0LkQIVG252eF1VRw=="
     },
     "node_modules/@dcl/react-ecs": {
-      "version": "7.3.18",
-      "resolved": "https://registry.npmjs.org/@dcl/react-ecs/-/react-ecs-7.3.18.tgz",
-      "integrity": "sha512-xL0FNSCnn1L/bOKfkowFPkstcp/RqJSmZ+atRLglgUGEb7+LLMg7AKxf/6FsccojZw+KJuvR0gS8V29xlZUHHQ==",
+      "version": "7.3.19",
+      "resolved": "https://registry.npmjs.org/@dcl/react-ecs/-/react-ecs-7.3.19.tgz",
+      "integrity": "sha512-loNPYPi1fqq8W0r1PdcCo/Vy6sBWdrF8PVCP44V23T5E3XAJsHD18C7c42KhQdbxiTM8Xssr1qSAAQJiqM05dA==",
       "dependencies": {
-        "@dcl/ecs": "7.3.18",
+        "@dcl/ecs": "7.3.19",
         "react": "^18.2.0",
         "react-reconciler": "^0.29.0"
       }
@@ -860,27 +881,27 @@
       "license": "MIT"
     },
     "node_modules/@dcl/sdk": {
-      "version": "7.3.18",
-      "resolved": "https://registry.npmjs.org/@dcl/sdk/-/sdk-7.3.18.tgz",
-      "integrity": "sha512-z9MoibCdNPjnqSVwWcT/8BZllU8QUX+ny3lsRipHVn6864JB8lF9qA5feKfxyCT16BK8Jn/obWGUe6mCEBKNEg==",
+      "version": "7.3.19",
+      "resolved": "https://registry.npmjs.org/@dcl/sdk/-/sdk-7.3.19.tgz",
+      "integrity": "sha512-loL+2FqhvNTQgzc53ao3mMH3h/UzPQ/M1XUQSEeKRnsNt9krAw2OiDR2fLs1INa5n0pP9HjqWVCmEiFaW8OtbQ==",
       "dependencies": {
-        "@dcl/ecs": "7.3.18",
+        "@dcl/ecs": "7.3.19",
         "@dcl/ecs-math": "2.0.2",
         "@dcl/explorer": "1.0.148846-20231002132009.commit-60a8fe3",
-        "@dcl/js-runtime": "7.3.18",
-        "@dcl/react-ecs": "7.3.18",
-        "@dcl/sdk-commands": "7.3.18"
+        "@dcl/js-runtime": "7.3.19",
+        "@dcl/react-ecs": "7.3.19",
+        "@dcl/sdk-commands": "7.3.19"
       }
     },
     "node_modules/@dcl/sdk-commands": {
-      "version": "7.3.18",
-      "resolved": "https://registry.npmjs.org/@dcl/sdk-commands/-/sdk-commands-7.3.18.tgz",
-      "integrity": "sha512-4H+X3HxSBzkp2t+cKPAl1PbDvFpdgT+eGA/fKGLcukU68nC/lgFIg0ehs+2X5IS5IA/PnvMl78EWrIxBsPMlhg==",
+      "version": "7.3.19",
+      "resolved": "https://registry.npmjs.org/@dcl/sdk-commands/-/sdk-commands-7.3.19.tgz",
+      "integrity": "sha512-8bofuDGtK5uJ9H+Gw4DnU2k4ZGrLArHyI6J63iPMU5mT7lQenLRB8/Q92xrtre1qIsjzB5azg56xiTNsXoKiLg==",
       "dependencies": {
         "@dcl/crypto": "^3.4.4",
-        "@dcl/ecs": "7.3.18",
+        "@dcl/ecs": "7.3.19",
         "@dcl/hashing": "1.1.3",
-        "@dcl/inspector": "7.3.18",
+        "@dcl/inspector": "7.3.19",
         "@dcl/linker-dapp": "^0.11.0",
         "@dcl/mini-comms": "1.0.1-20230216163137.commit-a4c75be",
         "@dcl/protocol": "1.0.0-6314457636.commit-a9a962a",
@@ -921,9 +942,12 @@
       "integrity": "sha512-4xRIlrXTrUIZEf/TmZY4xiF7ZC1ixJJvCwEct1Xtyt3hrqVpfetuuzgBfKOvsy4kUu2syJ3hI8QL/vPO5CigcA=="
     },
     "node_modules/@dcl/sdk-commands/node_modules/@dcl/inspector": {
-      "version": "7.3.18",
-      "resolved": "https://registry.npmjs.org/@dcl/inspector/-/inspector-7.3.18.tgz",
-      "integrity": "sha512-cPrORAjCqQExZyrW1wJWty6ONSEof7orILZ3wrCCewXHZ4ifV6UeXvHk/p4A+6XEys2n/QtXfVvv+c3GLde8Cw=="
+      "version": "7.3.19",
+      "resolved": "https://registry.npmjs.org/@dcl/inspector/-/inspector-7.3.19.tgz",
+      "integrity": "sha512-BNkNmwUAVVDU7OevKNSN1dzrhWWvx64KmYmp/qJAoAnjznMQGd6avrq7oyXmp59S+2K+1Rdvj2y/5BoUMnrayg==",
+      "dependencies": {
+        "@dcl/asset-packs": "^1.2.1"
+      }
     },
     "node_modules/@dcl/sdk-commands/node_modules/@dcl/linker-dapp": {
       "version": "0.11.0",
@@ -2121,9 +2145,9 @@
       }
     },
     "node_modules/@segment/analytics-core": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@segment/analytics-core/-/analytics-core-1.3.1.tgz",
-      "integrity": "sha512-KGblJ8WQNC4t0j31zeyYBm2thHWuPULNAoP7waU5ts7Asz9ipvGoHqFSLG6warqvcnBdkiRbNam242zmxX53oA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@segment/analytics-core/-/analytics-core-1.3.2.tgz",
+      "integrity": "sha512-NpeBCfOyMdO2/BDKfhCUNHcEwxg88N2iTnswBoEMh38rtsQ03TWLVYwgiTakPjNQFezdKkR6jq3JhQ3WWgq67g==",
       "dependencies": {
         "@lukeed/uuid": "^2.0.0",
         "dset": "^3.1.2",
@@ -2131,12 +2155,12 @@
       }
     },
     "node_modules/@segment/analytics-node": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@segment/analytics-node/-/analytics-node-1.1.1.tgz",
-      "integrity": "sha512-YNn32SfD8KrxIBowLz3MVav0GzhGIbBRgAtjW4Kv57oHwgaJNSLEp/z/ypnu7vAqUjm9jAwAW9Wfc24ssZI49g==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@segment/analytics-node/-/analytics-node-1.1.2.tgz",
+      "integrity": "sha512-pYQwG4/1YDxwzu97v2glfxZpwMj3A7UOKId1IdnSyDharesYawdbXpiTxBqOS3JpgP7iU4TZSiRmk7InFel/MA==",
       "dependencies": {
         "@lukeed/uuid": "^2.0.0",
-        "@segment/analytics-core": "1.3.1",
+        "@segment/analytics-core": "1.3.2",
         "buffer": "^6.0.3",
         "node-fetch": "^2.6.7",
         "tslib": "^2.4.1"
@@ -6596,8 +6620,9 @@
       }
     },
     "node_modules/mitt": {
-      "version": "3.0.0",
-      "license": "MIT"
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw=="
     },
     "node_modules/mkdirp": {
       "version": "0.5.6",

--- a/package.json
+++ b/package.json
@@ -422,7 +422,7 @@
   "dependencies": {
     "@dcl/inspector": "7.3.4",
     "@dcl/schemas": "^5.18.1",
-    "@dcl/sdk": "7.3.19",
+    "@dcl/sdk": "7.3.20",
     "@dcl/wearable-preview": "^1.14.0",
     "@sentry/node": "^7.64.0",
     "@types/analytics-node": "^3.1.9",

--- a/package.json
+++ b/package.json
@@ -422,7 +422,7 @@
   "dependencies": {
     "@dcl/inspector": "7.3.4",
     "@dcl/schemas": "^5.18.1",
-    "@dcl/sdk": "7.3.18",
+    "@dcl/sdk": "7.3.19",
     "@dcl/wearable-preview": "^1.14.0",
     "@sentry/node": "^7.64.0",
     "@types/analytics-node": "^3.1.9",

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -11,13 +11,5 @@ export async function install() {
     return
   }
 
-  const YES = 'Yes'
-  const NO = 'No'
-
-  const isLibrary = await vscode.window.showQuickPick([YES, NO], {
-    ignoreFocusOut: true,
-    title: 'Is this a Decentraland library?',
-  })
-
-  return npmInstall(dependency, isLibrary === YES)
+  return npmInstall(dependency)
 }

--- a/src/modules/notification.ts
+++ b/src/modules/notification.ts
@@ -25,16 +25,19 @@ export async function notifyUpdate(
 
   // Check if the version has been an updated and notify if so
   if (semver.gt(currentVersion, prevVersion)) {
-    const didClick = await vscode.window.showInformationMessage(
-      `${title} has been updated to v${currentVersion}!`,
-      `Learn More`
-    )
-    if (didClick) {
-      await vscode.env.openExternal(
-        vscode.Uri.parse(
-          `https://github.com/${repo}/releases/tag/${currentVersion}`
-        )
+    void vscode.window
+      .showInformationMessage(
+        `${title} has been updated to v${currentVersion}!`,
+        `Learn More`
       )
-    }
+      .then((didClick) => {
+        if (didClick) {
+          return vscode.env.openExternal(
+            vscode.Uri.parse(
+              `https://github.com/${repo}/releases/tag/${currentVersion}`
+            )
+          )
+        }
+      })
   }
 }

--- a/src/modules/npm.spec.ts
+++ b/src/modules/npm.spec.ts
@@ -126,15 +126,6 @@ describe('npm', () => {
             ProgressLocation.Window
           )
         })
-        describe('and the dependency is a decentraland library', () => {
-          it('should bundle the dependency', async () => {
-            await npmInstall('dcl-library', true)
-            expect(binMock).toHaveBeenCalledWith('npm', 'npm', [
-              'install --save-bundle',
-              'dcl-library',
-            ])
-          })
-        })
       })
     })
     describe('and the installation fails', () => {

--- a/src/modules/npm.ts
+++ b/src/modules/npm.ts
@@ -12,17 +12,14 @@ import { getMessage } from './error'
  * @param dependencies List of npm packages
  * @returns Promise that resolves when the install finishes
  */
-export async function npmInstall(dependency?: string, isLibrary = false) {
+export async function npmInstall(dependency?: string) {
   try {
     return await loader(
       dependency ? `Installing ${dependency}...` : `Installing dependencies...`,
       async () => {
         await runSceneServer.stop()
         track(`npm.install`, { dependency: dependency || null })
-        await bin('npm', 'npm', [
-          dependency && isLibrary ? 'install --save-bundle' : 'install',
-          dependency,
-        ]).wait()
+        await bin('npm', 'npm', ['install', dependency]).wait()
         await restart() // restart server after installing packages
       },
       dependency

--- a/src/views/inspector/webview.ts
+++ b/src/views/inspector/webview.ts
@@ -5,6 +5,8 @@ import { getExtensionPath } from '../../modules/path'
 import { waitForServer } from '../../modules/server'
 import { ServerName } from '../../types'
 import { getServerUrl } from '../../utils'
+import { hasDependency } from '../../modules/pkg'
+import { log } from '../../modules/log'
 
 export async function createWebview() {
   const panel = vscode.window.createWebviewPanel(
@@ -29,9 +31,17 @@ export async function createWebview() {
 
   const html = await fetch(url).then((res) => res.text())
 
+  const hasAssetPacksInstalled = hasDependency('@dcl/asset-packs', true)
+
+  log(
+    hasAssetPacksInstalled
+      ? '@dcl/asset-packs is installed'
+      : '@dcl/asset-packs is not installed'
+  )
+
   const config = {
     dataLayerRpcWsUrl: dataLayerRpcWsUrl,
-    disableSmartItems: true,
+    disableSmartItems: !hasAssetPacksInstalled,
   }
 
   panel.webview.html = html


### PR DESCRIPTION
This PR adds support for smart items on the Editor. 
It also removes the prompt for decentraland libraries, since that is not used anymore in SDK7.
Finally it also removes an await on the notification that says that the SDK has been updated, so it doesn't block the start of the dev server until the user acknowledges it.