### PR TITLE
chore: Update @dcl/sdk version to 7.4.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@dcl/schemas": "^5.18.1",
-        "@dcl/sdk": "^7.4.5",
+        "@dcl/sdk": "^7.4.7",
         "@dcl/wearable-preview": "^1.14.0",
         "@sentry/node": "^7.64.0",
         "@types/analytics-node": "^3.1.9",
@@ -629,13 +629,12 @@
       "license": "MIT"
     },
     "node_modules/@dcl/asset-packs": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@dcl/asset-packs/-/asset-packs-1.12.2.tgz",
-      "integrity": "sha512-jIkXrsfeG1zL52Opyz5hvqbeBL0Pjt6B/oPnXfNbc0+AwmiSnsR4+jMbpaOd5OQMClgr1vReik3buirm+JoEDg==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@dcl/asset-packs/-/asset-packs-1.13.0.tgz",
+      "integrity": "sha512-StD+ug9h0LKXSVD2mOqLjkxhu7VggykevLw3Vno8WPXH3HwjjEcrqIMFTSslAe87NEiqkFr76s2eAC2USdiANg==",
       "dependencies": {
         "@dcl-sdk/utils": "^1.2.6",
-        "@dcl/js-runtime": "^7.4.2",
-        "@dcl/sdk": "^7.4.2",
+        "@dcl/sdk": "7.4.7",
         "mitt": "^3.0.1"
       }
     },
@@ -717,9 +716,9 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
     "node_modules/@dcl/ecs": {
-      "version": "7.4.5",
-      "resolved": "https://registry.npmjs.org/@dcl/ecs/-/ecs-7.4.5.tgz",
-      "integrity": "sha512-hNhEzABVBMYnmDz87vfn3qXir/XCUqbzorbkyGIfWzLoDFYcCLSpAbAQZ6zcAiaZl9yCYOxYetXNAmab4ci1xQ=="
+      "version": "7.4.7",
+      "resolved": "https://registry.npmjs.org/@dcl/ecs/-/ecs-7.4.7.tgz",
+      "integrity": "sha512-k0xYenP9S399Dt+CRPWlRiYH2TQIpe04Gc9K0gDV0Ns1KyNkBJgulwPTWU50ZKZHj1aF1uDpE++vfxyRfzCeHA=="
     },
     "node_modules/@dcl/ecs-math": {
       "version": "2.0.2",
@@ -742,18 +741,18 @@
       }
     },
     "node_modules/@dcl/inspector": {
-      "version": "7.4.5",
-      "resolved": "https://registry.npmjs.org/@dcl/inspector/-/inspector-7.4.5.tgz",
-      "integrity": "sha512-4ug4qS31Z1/Qwbh0pWDyiRtExaCUoPZb1E5S69DnWLvpVnWC1n07Vo7BXU9vmqJ/JKJvjIUtfSa4bF87kbG+Dg==",
+      "version": "7.4.7",
+      "resolved": "https://registry.npmjs.org/@dcl/inspector/-/inspector-7.4.7.tgz",
+      "integrity": "sha512-0POwSm4wUvC4Dkuv58UGClEDJhXVpNjceWcuzSjqeDw0x+Aw5zJaLce5Fl9oApt+cEgj6E5xrdsq/NL/HWkHWw==",
       "dependencies": {
         "@dcl/asset-packs": "^1.12.2",
         "ts-deepmerge": "^7.0.0"
       }
     },
     "node_modules/@dcl/js-runtime": {
-      "version": "7.4.5",
-      "resolved": "https://registry.npmjs.org/@dcl/js-runtime/-/js-runtime-7.4.5.tgz",
-      "integrity": "sha512-EBj9waFym0fvQA4kwe1LCVYichGt/YN4os+m9pkvIOx5Ta/RrkfyTy6fNHuIyBHT2QxM++f+OsMEH2yXu2rAGg=="
+      "version": "7.4.7",
+      "resolved": "https://registry.npmjs.org/@dcl/js-runtime/-/js-runtime-7.4.7.tgz",
+      "integrity": "sha512-ZT3QRVPIZV2ASCynoC0Gl/Ix91DL/sUgcFPEXZiBMs8lEmOBTC/ONBuf+nqSKyBPRyKEAqAz4Yea5xasDnc7dg=="
     },
     "node_modules/@dcl/kernel": {
       "version": "2.0.0-3488762509.commit-68db89b",
@@ -835,11 +834,11 @@
       "integrity": "sha512-IPB043+NbQB3om2FlmQGmaRxTokHaSM9o3a7sEL0yJgBb60mukCpMdNXxzdIcemixfV3EhIJQ2G8HgK30XKTkA=="
     },
     "node_modules/@dcl/react-ecs": {
-      "version": "7.4.5",
-      "resolved": "https://registry.npmjs.org/@dcl/react-ecs/-/react-ecs-7.4.5.tgz",
-      "integrity": "sha512-aClH865GKA3i2JdEKaq1SyXSByFkWJn3e7TroKHy5ajyp7hLhqDHQcQytBFwW6WDi24nzQ3JvDMzmCDELC2KeQ==",
+      "version": "7.4.7",
+      "resolved": "https://registry.npmjs.org/@dcl/react-ecs/-/react-ecs-7.4.7.tgz",
+      "integrity": "sha512-7M/kAchsPB41F2YQFi6yjDCmCLTlsXL3cQBmFBsW8KjQszJ/mIHVvCeEdF2uzCoYz9EFfN+AuWSulWWu0q9sgg==",
       "dependencies": {
-        "@dcl/ecs": "7.4.5",
+        "@dcl/ecs": "7.4.7",
         "react": "^18.2.0",
         "react-reconciler": "^0.29.0"
       }
@@ -898,28 +897,28 @@
       "license": "MIT"
     },
     "node_modules/@dcl/sdk": {
-      "version": "7.4.5",
-      "resolved": "https://registry.npmjs.org/@dcl/sdk/-/sdk-7.4.5.tgz",
-      "integrity": "sha512-QehNZUIpBrUaBX7dME1tIWSOYw/0oCf6g/HsL3DVKi6tK4VlKtd9DgtRFQJO5ezN16oOW37A4zZcAAnF9YteIQ==",
+      "version": "7.4.7",
+      "resolved": "https://registry.npmjs.org/@dcl/sdk/-/sdk-7.4.7.tgz",
+      "integrity": "sha512-U2X4PufRpfVDpb2Bz1hcg62d8vefj/2ezSeViF9sqMl4+ACkS0CTNt2RRTuMRpaerq8BNsOun9gOjZ02abPCaA==",
       "dependencies": {
-        "@dcl/ecs": "7.4.5",
+        "@dcl/ecs": "7.4.7",
         "@dcl/ecs-math": "2.0.2",
         "@dcl/explorer": "1.0.160056-20240212151637.commit-33b7e01",
-        "@dcl/js-runtime": "7.4.5",
-        "@dcl/react-ecs": "7.4.5",
-        "@dcl/sdk-commands": "7.4.5",
+        "@dcl/js-runtime": "7.4.7",
+        "@dcl/react-ecs": "7.4.7",
+        "@dcl/sdk-commands": "7.4.7",
         "text-encoding": "0.7.0"
       }
     },
     "node_modules/@dcl/sdk-commands": {
-      "version": "7.4.5",
-      "resolved": "https://registry.npmjs.org/@dcl/sdk-commands/-/sdk-commands-7.4.5.tgz",
-      "integrity": "sha512-1h1lcc4Waf1QHcfqhxrNX4ekvSB3nOUkU0SQxsA8KXaxzrJvYjJAjkBARkmRCcDRrjOvXciOEFzIWgxigxFAng==",
+      "version": "7.4.7",
+      "resolved": "https://registry.npmjs.org/@dcl/sdk-commands/-/sdk-commands-7.4.7.tgz",
+      "integrity": "sha512-UlaGMT603Q0Yh/XwqNqZbp49zViC0p4lC7WMUzfU+zC+7UgVE8P/w4iQdpruiJuXaZ2qY+EcdzBemBnykf6TdA==",
       "dependencies": {
         "@dcl/crypto": "^3.4.4",
-        "@dcl/ecs": "7.4.5",
+        "@dcl/ecs": "7.4.7",
         "@dcl/hashing": "1.1.3",
-        "@dcl/inspector": "7.4.5",
+        "@dcl/inspector": "7.4.7",
         "@dcl/linker-dapp": "^0.12.0",
         "@dcl/mini-comms": "1.0.1-20230216163137.commit-a4c75be",
         "@dcl/protocol": "1.0.0-7716486147.commit-7433b10",
@@ -1662,9 +1661,9 @@
       }
     },
     "node_modules/@fastify/busboy": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.0.tgz",
-      "integrity": "sha512-+KpH+QxZU7O4675t3mnkQKcZZg56u+K/Ct2K+N2AZYNVK8kyeo/bI18tI8aPm3tvNNRyTWfj6s5tnGNlcbQRsA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
       "engines": {
         "node": ">=14"
       }

--- a/package.json
+++ b/package.json
@@ -421,7 +421,7 @@
   },
   "dependencies": {
     "@dcl/schemas": "^5.18.1",
-    "@dcl/sdk": "^7.4.5",
+    "@dcl/sdk": "^7.4.7",
     "@dcl/wearable-preview": "^1.14.0",
     "@sentry/node": "^7.64.0",
     "@types/analytics-node": "^3.1.9",


### PR DESCRIPTION
This PR updates the package `@dcl/sdk` to the version `7.4.7`