### PR TITLE
fix: remove ansii escape codes from vscode logs

### DIFF
--- a/src/modules/log.spec.ts
+++ b/src/modules/log.spec.ts
@@ -41,6 +41,10 @@ describe('log', () => {
       append('message')
       expect(appendSpy).toHaveBeenCalledWith('message')
     })
+    it('should remove ansii escape codes', () => {
+      append('\x1b[1mHello World!\x1b[0m')
+      expect(appendSpy).toHaveBeenCalledWith('Hello World!')
+    })
   })
   describe('When appending a line', () => {
     it('should append the message with a new line to the output channel', () => {

--- a/src/modules/log.ts
+++ b/src/modules/log.ts
@@ -7,7 +7,12 @@ export const output = vscode.window.createOutputChannel(`Decentraland SDK7`)
  * Append a message to the output
  */
 export function append(message: string) {
-  output.append(message)
+  // remove ansi escape codes
+  const sanitized = message.replace(
+    /[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g,
+    ''
+  )
+  output.append(sanitized)
 }
 
 /**
@@ -46,7 +51,7 @@ export function log(...messages: string[]) {
 export function bind(child: SpanwedChild) {
   child.on(/.*/, (data) => {
     if (data) {
-      output.append(data)
+      append(data)
       // focus on errors, but not the ones about outdated packages
       if (/err/gi.test(data) && !/outdated/gi.test(data)) {
         focus()


### PR DESCRIPTION
Fixes https://github.com/decentraland/sdk/issues/860

The problem was that some logs from `@dcl/sdk-commands` are meant for the console and they contain ansii escape codes to format the output. These don't work on VSCode's output tab, so I fltered them out using a regex that I took from [StackOverflow](https://stackoverflow.com/questions/7149601/how-to-remove-replace-ansi-color-codes-from-a-string-in-javascript).

Added a test too.

### BEFORE:
![Screenshot 2024-04-03 at 5 53 47 PM](https://github.com/decentraland/editor-sdk7/assets/2781777/ee968431-8324-4716-a772-4ff0cc2b693b)


### AFTER:
![Screenshot 2024-04-03 at 5 52 47 PM](https://github.com/decentraland/editor-sdk7/assets/2781777/e8140b1c-52c4-4350-8f7d-c6e51eadb548)

