### PR TITLE
fix: publish

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -18,11 +18,10 @@ jobs:
         run: npm install
 
       - name: get latest release
-        uses: rez0n/actions-github-release@v2.0
+        uses: pozetroninc/github-action-get-latest-release@master@v0.7.0
         id: editor_release
         with:
           repository: 'decentraland/editor-sdk7'
-          type: 'stable'
 
       - name: get commit
         run: echo "COMMIT_HASH=$(git rev-parse --short "$GITHUB_SHA")"  >> $GITHUB_ENV

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -18,7 +18,7 @@ jobs:
         run: npm install
 
       - name: get latest release
-        uses: pozetroninc/github-action-get-latest-release@master@v0.7.0
+        uses: pozetroninc/github-action-get-latest-release@v0.7.0
         id: editor_release
         with:
           repository: 'decentraland/editor-sdk7'

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -17,8 +17,18 @@ jobs:
       - name: npm install
         run: npm install
 
+      - name: get latest release
+        uses: rez0n/actions-github-release@v2.0
+        id: editor_release
+        with:
+          repository: 'decentraland/editor-sdk7'
+          type: 'stable'
+
+      - name: get commit
+        run: echo "COMMIT_HASH=$(git rev-parse --short "$GITHUB_SHA")"  >> $GITHUB_ENV
+
       - name: build artifact (vsix)
-        run: mkdir artifacts && npx vsce package -o "$_/editor-sdk7.vsix"
+        run: mkdir artifacts && npx vsce package ${{steps.editor_release.outputs.release}}-${{ env.COMMIT_HASH }} -o "$_/editor-sdk7.vsix"
 
       - name: upload artifact to S3
         run: npx @dcl/cdn-uploader@next --bucket ${{ secrets.SDK_TEAM_S3_BUCKET }} --local-folder $(pwd)/artifacts --bucket-folder 'editor-sdk7/branch/${{ github.head_ref || github.ref }}/artifacts'
@@ -48,6 +58,6 @@ jobs:
             - The `editor-sdk7` extension can be tested in VSCode by downloading [this](${{ secrets.SDK_TEAM_S3_BASE_URL }}/editor-sdk7/branch/${{ github.head_ref || github.ref }}/artifacts/editor-sdk7.vsix) `.vsix` file and running:
 
                ```bash
-               code --install-extension editor-sdk7.vsix
+               code --force --install-extension editor-sdk7.vsix
                ```
           edit-mode: replace

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -1,6 +1,6 @@
-on: [pull_request]
+on: [push]
 
-name: Package vsix
+name: Package .vsix
 jobs:
   artifact:
     runs-on: ubuntu-latest

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -40,18 +40,39 @@ jobs:
     runs-on: ubuntu-latest
     name: Deployment Notification
     steps:
+      - name: Get issue number
+        uses: actions/github-script@v6
+        id: get_issue_number
+        with:
+          script: |
+            if (context.issue.number) {
+              // Return issue number if present
+              return context.issue.number;
+            } else {
+              // Otherwise return issue number from commit
+              return (
+                await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                  commit_sha: context.sha,
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                })
+              ).data[0].number;
+            }
+          result-encoding: string
+      - name: Log issue number
+        run: echo '${{steps.get_issue_number.outputs.result}}'
       - name: Find Comment
         uses: peter-evans/find-comment@v1
         id: fc
         with:
-          issue-number: ${{ github.event.pull_request.number }}
+          issue-number: ${{ steps.get_issue_number.outputs.result }}
           comment-author: 'github-actions[bot]'
           body-includes: Test this pull request
       - name: Create or update comment
         uses: peter-evans/create-or-update-comment@v1
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}
-          issue-number: ${{ github.event.pull_request.number }}
+          issue-number: ${{steps.get_issue_number.outputs.result}}
           body: |
             # Test this pull request
             - The `editor-sdk7` extension can be tested in VSCode by downloading [this](${{ secrets.SDK_TEAM_S3_BASE_URL }}/editor-sdk7/branch/${{ github.head_ref || github.ref }}/artifacts/editor-sdk7.vsix) `.vsix` file and running:

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -27,7 +27,7 @@ jobs:
         run: echo "COMMIT_HASH=$(git rev-parse --short "$GITHUB_SHA")"  >> $GITHUB_ENV
 
       - name: build artifact (vsix)
-        run: mkdir artifacts && npx vsce package ${{steps.editor_release.outputs.release}}-${{ env.COMMIT_HASH }} -o "$_/editor-sdk7.vsix"
+        run: git config --global user.name "decentraland" && git config --global user.email "muna@decentraland.org" && mkdir artifacts && npx vsce package ${{steps.editor_release.outputs.release}}-${{ env.COMMIT_HASH }} -o "$_/editor-sdk7.vsix"
 
       - name: upload artifact to S3
         run: npx @dcl/cdn-uploader@next --bucket ${{ secrets.SDK_TEAM_S3_BUCKET }} --local-folder $(pwd)/artifacts --bucket-folder 'editor-sdk7/branch/${{ github.head_ref || github.ref }}/artifacts'

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -11,25 +11,25 @@ jobs:
           node-version: 18
           cache: 'npm'
 
-      - name: install cdn-uploader
+      - name: Install cdn-uploader
         run: npm i -g @dcl/cdn-uploader@next
 
-      - name: npm install
+      - name: Install dependencies
         run: npm install
 
-      - name: get latest release
+      - name: Get latest release
         uses: pozetroninc/github-action-get-latest-release@v0.7.0
         id: editor_release
         with:
           repository: 'decentraland/editor-sdk7'
 
-      - name: get commit
+      - name: Get commit hash
         run: echo "COMMIT_HASH=$(git rev-parse --short "$GITHUB_SHA")"  >> $GITHUB_ENV
 
-      - name: build artifact (vsix)
+      - name: Build artifact (.vsix)
         run: git config --global user.name "decentraland" && git config --global user.email "muna@decentraland.org" && mkdir artifacts && npx vsce package ${{steps.editor_release.outputs.release}}-${{ env.COMMIT_HASH }} -o "$_/editor-sdk7.vsix"
 
-      - name: upload artifact to S3
+      - name: Upload artifact to S3
         run: npx @dcl/cdn-uploader@next --bucket ${{ secrets.SDK_TEAM_S3_BUCKET }} --local-folder $(pwd)/artifacts --bucket-folder 'editor-sdk7/branch/${{ github.head_ref || github.ref }}/artifacts'
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.SDK_TEAM_AWS_ID }}
@@ -59,8 +59,6 @@ jobs:
               ).data[0].number;
             }
           result-encoding: string
-      - name: Log issue number
-        run: echo '${{steps.get_issue_number.outputs.result}}'
       - name: Find Comment
         uses: peter-evans/find-comment@v1
         id: fc
@@ -75,7 +73,7 @@ jobs:
           issue-number: ${{steps.get_issue_number.outputs.result}}
           body: |
             # Test this pull request
-            - The `editor-sdk7` extension can be tested in VSCode by downloading [this](${{ secrets.SDK_TEAM_S3_BASE_URL }}/editor-sdk7/branch/${{ github.head_ref || github.ref }}/artifacts/editor-sdk7.vsix) `.vsix` file and running:
+            - The `editor-sdk7` extension can be tested in VSCode by downloading [this package](${{ secrets.SDK_TEAM_S3_BASE_URL }}/editor-sdk7/branch/${{ github.head_ref || github.ref }}/artifacts/editor-sdk7.vsix) and running:
 
                ```bash
                code --force --install-extension editor-sdk7.vsix

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 node_modules
 out
-decentraland-*.vsix
+*.vsix
 .env
 coverage
 dist

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,1 +1,11 @@
-node_modules/**/*.{ts,map}
+node_modules
+!node_modules/.bin/npm
+!node_modules/npm
+src
+coverage
+scripts
+.env.example
+.gitignore
+jest.config.ts
+tsconfig.json
+README.md

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -16,7 +16,7 @@ import { init } from './commands/init'
 import { restart } from './commands/restart'
 import { inspector } from './commands/inspector'
 import { Dependency } from './views/dependency-tree/types'
-import { npmInstall, npmUninstall } from './modules/npm'
+import { installExtension, npmInstall, npmUninstall } from './modules/npm'
 import { checkNodeBinaries, resolveVersion, setVersion } from './modules/node'
 import { unwatch, watch } from './modules/watch'
 import { log } from './modules/log'
@@ -200,6 +200,9 @@ export async function activate(context: vscode.ExtensionContext) {
 
     // Check node binaries, download them if necessary
     await checkNodeBinaries()
+
+    // Install extension dependencies
+    await installExtension()
 
     // Check and notify updated version for @dcl/sdk
     await notifyUpdate(

--- a/src/modules/npm.ts
+++ b/src/modules/npm.ts
@@ -3,12 +3,7 @@ import { loader } from './loader'
 import { bin } from './bin'
 import { restart } from '../commands/restart'
 import { runSceneServer } from '../views/run-scene/server'
-import {
-  getLocalValue,
-  setLocalValue,
-  getGlobalValue,
-  setGlobalValue,
-} from './storage'
+import { getGlobalValue, setGlobalValue } from './storage'
 import { track } from './analytics'
 import { getMessage } from './error'
 import { getExtensionPath } from './path'
@@ -82,55 +77,5 @@ export async function installExtension() {
     }
   } catch (error) {
     throw new Error(`Error installing extension: ${getMessage(error)}`)
-  }
-}
-
-/**
- * Warns the user that a dependency is outdated, allows them to upgrade it
- * @param dependency
- * @returns
- */
-export async function warnOutdatedDependency(dependency: string) {
-  const storageKey = `ignore:${dependency}`
-  const isIgnored = getLocalValue<boolean>(storageKey)
-  if (isIgnored) {
-    return
-  }
-  const update = 'Update'
-  const ignore = 'Ignore'
-  track(`npm.warn_outdated_dependency:show`)
-  const action = await vscode.window.showWarningMessage(
-    `The dependency "${dependency}" is outdated`,
-    update,
-    ignore
-  )
-  if (action === update) {
-    await npmInstall(`${dependency}@latest`)
-    track(`npm.warn_outdated_dependency:update`)
-  } else if (action === ignore) {
-    setLocalValue(storageKey, true)
-    track(`npm.warn_outdated_dependency:ignore`)
-  }
-}
-
-/**
- * Warns the user that a dependency that is installed as a library is not, allows them to reinstall it
- * @param dependency
- */
-export async function warnDecentralandLibrary(dependency: string) {
-  const reinstall = 'Re-install'
-  const remove = 'Remove'
-  track(`npm.warn_decentraland_library:show`)
-  const action = await vscode.window.showErrorMessage(
-    `The dependency "${dependency}" is not a valid Decentraland library. You can re-install it as non-library, or remove it.`,
-    reinstall,
-    remove
-  )
-  await npmUninstall(dependency)
-  if (action === reinstall) {
-    await npmInstall(dependency)
-    track(`npm.warn_decentraland_library:reinstall`)
-  } else {
-    track(`npm.warn_decentraland_library:remove`)
   }
 }


### PR DESCRIPTION
The CI is currently failing to publish new versions of the extension because the size of the package is too large (+400mb). See [v1.48.0](https://github.com/decentraland/editor-sdk7/actions/runs/8523729302) and [v1.48.1](https://github.com/decentraland/editor-sdk7/actions/runs/8559260738).

This PR ignores everything in `node_modules` except for `npm` and it uses it to install the rest of the dependencies when the extension is activated. This reduces the size of the package to just 4mb:

<img width="380" alt="Screenshot 2024-04-05 at 4 11 46 PM" src="https://github.com/decentraland/editor-sdk7/assets/2781777/c7d79a1e-3090-4a92-b666-93cee59cd706">

It will store the extension version in global storage so it doesn't install the dependencies again for a version that has already been installed.

A few test were added to keep the coverage at 100%.

It also adds the latest version and commit hash to the artifact created on each PR, this makes it easier to install test version and know which version you are running. The way it worked before it always had the `0.0.0-development` version, which VSCode always auto-updated to the latest version on every refresh, so it was very annoying to use it for test purposes (you had to keep reinstalling the test version every time you open VSCode).

It also fixed an issue with the CI where it would only build the .vsix artifact when the PR was opened, but it would not rebuild it on subsequent commits. Now it generates a new .vsix on every commit.

Finally, it removes a few unused functions `warnDecentralandLibrary` and `warnOutdatedDependency` which are not used anymore, and it also removed the tests related to them.