### PR TITLE
feat: clean cache and retry on error

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -1,6 +1,8 @@
-on: [push]
-
 name: Package .vsix
+
+on:
+  pull_request:
+
 jobs:
   artifact:
     runs-on: ubuntu-latest

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -25,11 +25,14 @@ jobs:
         with:
           repository: 'decentraland/editor-sdk7'
 
+      - name: Increment version
+        run: echo "PACKAGE_VERSION=$(npx semver -i patch ${{steps.editor_release.outputs.release}})"  >> $GITHUB_ENV
+
       - name: Get commit hash
         run: echo "COMMIT_HASH=$(git rev-parse --short "$GITHUB_SHA")"  >> $GITHUB_ENV
 
       - name: Build artifact (.vsix)
-        run: git config --global user.name "decentraland" && git config --global user.email "muna@decentraland.org" && git stash -u && mkdir artifacts && npx vsce package ${{steps.editor_release.outputs.release}}-${{ env.COMMIT_HASH }} -o "$_/editor-sdk7.vsix"
+        run: git config --global user.name "decentraland" && git config --global user.email "muna@decentraland.org" && git stash -u && mkdir artifacts && npx vsce package ${{env.PACKAGE_VERSION}}-${{ env.COMMIT_HASH }} -o "$_/editor-sdk7.vsix"
 
       - name: Upload artifact to S3
         run: npx @dcl/cdn-uploader@next --bucket ${{ secrets.SDK_TEAM_S3_BUCKET }} --local-folder $(pwd)/artifacts --bucket-folder 'editor-sdk7/branch/${{ github.head_ref || github.ref }}/artifacts'

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -16,7 +16,12 @@ import { init } from './commands/init'
 import { restart } from './commands/restart'
 import { inspector } from './commands/inspector'
 import { Dependency } from './views/dependency-tree/types'
-import { installExtension, npmInstall, npmUninstall } from './modules/npm'
+import {
+  cleanExtension,
+  installExtension,
+  npmInstall,
+  npmUninstall,
+} from './modules/npm'
 import { checkNodeBinaries, resolveVersion, setVersion } from './modules/node'
 import { unwatch, watch } from './modules/watch'
 import { log } from './modules/log'
@@ -202,7 +207,13 @@ export async function activate(context: vscode.ExtensionContext) {
     await checkNodeBinaries()
 
     // Install extension dependencies
-    await installExtension()
+    try {
+      await installExtension()
+    } catch (error) {
+      // if something goes wrong, try to clean cache and install again
+      await cleanExtension()
+      await installExtension()
+    }
 
     // Check and notify updated version for @dcl/sdk
     await notifyUpdate(

--- a/src/modules/spawn.ts
+++ b/src/modules/spawn.ts
@@ -62,7 +62,7 @@ export function spawn(
   const newEnv = {
     ...env,
     PATH: joinEnvPaths(env.PATH, nodePath, npmPath),
-    EDITOR_SDK7: 'true'
+    EDITOR_SDK7: 'true',
   }
 
   const child = crossSpawn(command, args, {


### PR DESCRIPTION
It has been reported that the `npm install` sometimes fails and it can't recover until manually cleaning the cache. This PR wraps the installation of the extension in a try/catch, and if it fails, it cleans the cache (`npm cache clean --force`) and tries again.