### PR TITLE
feat: cache node modules

### DIFF
--- a/src/__mocks__/vscode.ts
+++ b/src/__mocks__/vscode.ts
@@ -33,6 +33,10 @@ export const workspace = {
       },
     },
   ],
+  fs: {
+    stat: jest.fn().mockResolvedValue({}),
+    copy: jest.fn().mockResolvedValue({}),
+  },
 }
 
 export const env = {
@@ -42,7 +46,8 @@ export const env = {
 
 export const Uri = {
   parse: jest.fn().mockImplementation((value) => value),
-  joinPath: (...paths: string[]) => paths.join(''),
+  file: jest.fn().mockImplementation((value) => value),
+  joinPath: (...paths: string[]) => paths.join('/'),
 }
 
 export const ExtensionMode = {

--- a/src/modules/fs.spec.ts
+++ b/src/modules/fs.spec.ts
@@ -1,0 +1,20 @@
+import { workspace } from 'vscode'
+import { exists } from './fs'
+
+describe('fs', () => {
+  describe('When checking if a path exists', () => {
+    it('should return true if the path exists', async () => {
+      const result = await exists('/path/to/file')
+      expect(result).toBe(true)
+    })
+    it('should return false if the path does not exist', async () => {
+      debugger
+      const statMock = workspace.fs.stat as jest.MockedFunction<
+        typeof workspace.fs.stat
+      >
+      statMock.mockRejectedValue({})
+      const result = await exists('/path/to/file')
+      expect(result).toBe(false)
+    })
+  })
+})

--- a/src/modules/fs.ts
+++ b/src/modules/fs.ts
@@ -1,0 +1,8 @@
+import * as vscode from 'vscode'
+
+export async function exists(path: string) {
+  return await vscode.workspace.fs.stat(vscode.Uri.file(path)).then(
+    () => true,
+    () => false
+  )
+}

--- a/src/modules/npm.spec.ts
+++ b/src/modules/npm.spec.ts
@@ -256,7 +256,7 @@ describe('npm', () => {
       it('should show a loader on the status bar', async () => {
         await installExtension()
         expect(loaderMock).toHaveBeenCalledWith(
-          'Updating Decentraland Editor v1.0.0...',
+          'Updating Decentraland Editor v1.0.0 [2/3]: Installing...',
           expect.any(Function),
           ProgressLocation.Notification
         )
@@ -411,7 +411,7 @@ describe('npm', () => {
       it('should show a loader', async () => {
         await cacheDependencies()
         expect(loaderMock).toHaveBeenCalledWith(
-          'Updating cache...',
+          'Updating Decentraland Editor v1.0.0 [3/3]: Saving cache...',
           expect.any(Function),
           ProgressLocation.Notification
         )
@@ -489,7 +489,7 @@ describe('npm', () => {
       it('should show a loader', async () => {
         await restoreDependencies()
         expect(loaderMock).toHaveBeenCalledWith(
-          'Restoring cache...',
+          'Updating Decentraland Editor v1.0.0 [1/3]: Restoring cache...',
           expect.any(Function),
           ProgressLocation.Notification
         )

--- a/src/modules/npm.ts
+++ b/src/modules/npm.ts
@@ -64,7 +64,7 @@ export async function installExtension() {
     if (!isInstalled) {
       log(`Installing extension v${version}...`)
       await loader(
-        `Updating Decentraland Editor v${version}...`,
+        `Updating Decentraland Editor v${version} [2/3]: Installing...`,
         async () => {
           track(`npm.install_extension`, { dependency: null })
           const child = bin('npm', 'npm', ['install'], {
@@ -118,7 +118,7 @@ export async function cacheDependencies() {
   const nodeModulesCachePath = getNodeModulesCachePath()
   log(`Updating cache into ${nodeModulesCachePath}`)
   await loader(
-    `Updating cache...`,
+    `Updating Decentraland Editor v${version} [3/3]: Saving cache...`,
     async () => {
       track(`npm.cache_node_modules`, { dependency: null })
       await vscode.workspace.fs.copy(
@@ -148,7 +148,7 @@ export async function restoreDependencies() {
   if (isInstalled) return
   log(`Restoring cache...`)
   await loader(
-    `Restoring cache...`,
+    `Updating Decentraland Editor v${version} [1/3]: Restoring cache...`,
     async () => {
       track(`npm.restore_node_modules`, { dependency: null })
       await vscode.workspace.fs.copy(

--- a/src/modules/npm.ts
+++ b/src/modules/npm.ts
@@ -7,9 +7,10 @@ import { runSceneServer } from '../views/run-scene/server'
 import { getGlobalValue, setGlobalValue } from './storage'
 import { track } from './analytics'
 import { getMessage } from './error'
-import { getExtensionPath } from './path'
+import { getExtensionPath, getNodeModulesCachePath } from './path'
 import { getPackageVersion } from './pkg'
 import { log } from './log'
+import { exists } from './fs'
 
 /**
  * Installs a list of npm packages, or install all dependencies if no list is provided
@@ -89,6 +90,9 @@ export async function installExtension() {
   }
 }
 
+/**
+ * Cleans the extension's npm cache
+ */
 export async function cleanExtension() {
   log(`Cleaning npm cache...`)
   await loader(
@@ -98,6 +102,63 @@ export async function cleanExtension() {
       await bin('npm', 'npm', ['cache', 'clean', '--force'], {
         cwd: getExtensionPath(),
       }).wait()
+    },
+    vscode.ProgressLocation.Notification
+  )
+}
+
+/**
+ * Caches the extension's dependencies
+ */
+export async function cacheDependencies() {
+  const version = getPackageVersion()
+  const key = `extension-cache:${version}`
+  const isCached = await getGlobalValue(key)
+  if (isCached) return
+  const nodeModulesCachePath = getNodeModulesCachePath()
+  log(`Updating cache into ${nodeModulesCachePath}`)
+  await loader(
+    `Updating cache...`,
+    async () => {
+      track(`npm.cache_node_modules`, { dependency: null })
+      await vscode.workspace.fs.copy(
+        vscode.Uri.joinPath(
+          vscode.Uri.parse(getExtensionPath()),
+          'node_modules'
+        ),
+        vscode.Uri.parse(nodeModulesCachePath),
+        { overwrite: true }
+      )
+    },
+    vscode.ProgressLocation.Notification
+  )
+  setGlobalValue(key, true)
+}
+
+/**
+ * Restore the extension's dependencies from cache
+ */
+export async function restoreDependencies() {
+  const nodeModulesCachePath = getNodeModulesCachePath()
+  const nodeModulesCacheExists = await exists(nodeModulesCachePath)
+  if (!nodeModulesCacheExists) return
+  const version = getPackageVersion()
+  const key = `extension:${version}`
+  const isInstalled = await getGlobalValue(key)
+  if (isInstalled) return
+  log(`Restoring cache...`)
+  await loader(
+    `Restoring cache...`,
+    async () => {
+      track(`npm.restore_node_modules`, { dependency: null })
+      await vscode.workspace.fs.copy(
+        vscode.Uri.parse(nodeModulesCachePath),
+        vscode.Uri.joinPath(
+          vscode.Uri.parse(getExtensionPath()),
+          'node_modules'
+        ),
+        { overwrite: true }
+      )
     },
     vscode.ProgressLocation.Notification
   )

--- a/src/modules/path.spec.ts
+++ b/src/modules/path.spec.ts
@@ -4,6 +4,7 @@ import {
   getGlobalStoragePath,
   getModuleBinPath,
   getNodeBinPath,
+  getNodeModulesCachePath,
   joinEnvPaths,
   setExtensionPath,
   setGlobalStoragePath,
@@ -102,7 +103,9 @@ describe('path', () => {
       describe('and the command is part of the binaries', () => {
         it('should return the path to the bin file', () => {
           expect(getModuleBinPath('some-module', 'cmd')).toBe(
-            convertSlashToInvertSlashIfWin32('/path/to/extension/node_modules/some-module/path/to/cmd.js')
+            convertSlashToInvertSlashIfWin32(
+              '/path/to/extension/node_modules/some-module/path/to/cmd.js'
+            )
           )
         })
       })
@@ -156,7 +159,9 @@ describe('path', () => {
       })
       it('should return the path to the Windows node bin', () => {
         expect(getNodeBinPath()).toBe(
-          convertSlashToInvertSlashIfWin32('/globalStorage/bin/node-v1.0.0-win-x64/node.exe')
+          convertSlashToInvertSlashIfWin32(
+            '/globalStorage/bin/node-v1.0.0-win-x64/node.exe'
+          )
         )
       })
     })
@@ -179,7 +184,9 @@ describe('path', () => {
       })
       it('should return the path to the MacOS node bin', () => {
         expect(getNodeBinPath()).toBe(
-          convertSlashToInvertSlashIfWin32('/globalStorage/bin/node-v1.0.0-darwin-arm64/bin/node')
+          convertSlashToInvertSlashIfWin32(
+            '/globalStorage/bin/node-v1.0.0-darwin-arm64/bin/node'
+          )
         )
       })
     })
@@ -235,8 +242,12 @@ describe('path', () => {
       })
       it('should return the two files', () => {
         expect(getFilePaths('/some/folder')).toEqual([
-          addDriveIfWin32(convertSlashToInvertSlashIfWin32('/some/folder/file1.txt')),
-          addDriveIfWin32(convertSlashToInvertSlashIfWin32('/some/folder/file2.txt')),
+          addDriveIfWin32(
+            convertSlashToInvertSlashIfWin32('/some/folder/file1.txt')
+          ),
+          addDriveIfWin32(
+            convertSlashToInvertSlashIfWin32('/some/folder/file2.txt')
+          ),
         ])
       })
     })
@@ -274,12 +285,37 @@ describe('path', () => {
       })
       it('should include the files in the subfolder', () => {
         expect(getFilePaths('/some/folder')).toEqual([
-          addDriveIfWin32(convertSlashToInvertSlashIfWin32('/some/folder/file1.txt')),
-          addDriveIfWin32(convertSlashToInvertSlashIfWin32('/some/folder/file2.txt')),
-          addDriveIfWin32(convertSlashToInvertSlashIfWin32('/some/folder/subfolder/subfile1.txt')),
-          addDriveIfWin32(convertSlashToInvertSlashIfWin32('/some/folder/subfolder/subfile2.txt')),
+          addDriveIfWin32(
+            convertSlashToInvertSlashIfWin32('/some/folder/file1.txt')
+          ),
+          addDriveIfWin32(
+            convertSlashToInvertSlashIfWin32('/some/folder/file2.txt')
+          ),
+          addDriveIfWin32(
+            convertSlashToInvertSlashIfWin32(
+              '/some/folder/subfolder/subfile1.txt'
+            )
+          ),
+          addDriveIfWin32(
+            convertSlashToInvertSlashIfWin32(
+              '/some/folder/subfolder/subfile2.txt'
+            )
+          ),
         ])
       })
+    })
+  })
+  describe('When getting the node modules cache path', () => {
+    beforeAll(() => {
+      setGlobalStoragePath('/globalStorage')
+    })
+    afterAll(() => {
+      setGlobalStoragePath(null)
+    })
+    it('should return the path to the cache folder for node_modules', () => {
+      expect(getNodeModulesCachePath()).toBe(
+        convertSlashToInvertSlashIfWin32('/globalStorage/.cache/node_modules')
+      )
     })
   })
 })

--- a/src/modules/path.ts
+++ b/src/modules/path.ts
@@ -153,3 +153,10 @@ export function getFilePaths(folder: string) {
   }
   return filePaths
 }
+
+/*
+ * Returns the path to the cache folder for node_modules
+ */
+export function getNodeModulesCachePath() {
+  return path.join(getGlobalStoragePath(), '.cache', 'node_modules')
+}


### PR DESCRIPTION
This PR adds two steps to the installation of the extension dependencies:

1. First, it restores the `node_modules` from the global cache (if it exists) by copying the `node_modules` from `{globalStorage}/.cache/node_modules` into `{extensionPath}/node_modules`
2. Second, it installs the extension's dependencies by running `npm install`
3. Third, it copies the freshly installed `node_modules` into the global cache at `{globalStorage}/.cache/node_modules` to keep the cache updated.

This makes the installation process faster for future version because it doesn't run the `npm install` on an empty `node_modules` but instead it keeps the ones from the previous version.