### PR TITLE
feat: prompt user instead of forcing the update of sdk

### DIFF
--- a/src/modules/sdk.spec.ts
+++ b/src/modules/sdk.spec.ts
@@ -4,9 +4,10 @@ import { syncSdkVersion } from './sdk'
                           Mocks
 *********************************************************/
 
-import { npmInstall } from './npm'
+import { warnOutdatedSdkVersion } from './npm'
 jest.mock('./npm')
-const npmInstallMock = npmInstall as jest.MockedFunction<typeof npmInstall>
+const warnOutdatedSdkVersionMock =
+  warnOutdatedSdkVersion as jest.MockedFunction<typeof warnOutdatedSdkVersion>
 
 import { getPackageVersion } from './pkg'
 jest.mock('./pkg')
@@ -38,27 +39,27 @@ describe('sdk', () => {
       })
       it('should not install the sdk', async () => {
         await syncSdkVersion()
-        expect(npmInstallMock).not.toHaveBeenCalled()
+        expect(warnOutdatedSdkVersionMock).not.toHaveBeenCalled()
       })
     })
-    describe('and the version of the workspace\'s @dcl/sdk is the same than the one on the extension', () => {
+    describe("and the version of the workspace's @dcl/sdk is the same than the one on the extension", () => {
       beforeEach(() => {
         extensionSdkVersion = '1.0.0'
         workspaceSdkVersion = extensionSdkVersion
       })
       it('should not install the sdk', async () => {
         await syncSdkVersion()
-        expect(npmInstallMock).not.toHaveBeenCalled()
+        expect(warnOutdatedSdkVersionMock).not.toHaveBeenCalled()
       })
     })
-    describe('and the version of the workspace\'s @dcl/sdk is different to the one on the extension', () => {
+    describe("and the version of the workspace's @dcl/sdk is different to the one on the extension", () => {
       beforeEach(() => {
         extensionSdkVersion = '2.0.0'
         workspaceSdkVersion = '1.0.0'
       })
       it('should install the extension version into the workspace', async () => {
         await syncSdkVersion()
-        expect(npmInstallMock).toHaveBeenCalledWith('@dcl/sdk@2.0.0')
+        expect(warnOutdatedSdkVersionMock).toHaveBeenCalledWith('2.0.0')
       })
     })
   })

--- a/src/modules/sdk.ts
+++ b/src/modules/sdk.ts
@@ -1,22 +1,20 @@
 import semver from 'semver'
 import { log } from './log'
-import { npmInstall } from './npm'
+import { warnOutdatedSdkVersion } from './npm'
 import { getPackageVersion } from './pkg'
 
 export async function syncSdkVersion() {
-  const extensionSdkVersion = getPackageVersion('@dcl/sdk')
+  const extensionSdkVersion = getPackageVersion('@dcl/sdk')!
   const workspaceSdkVersion = getPackageVersion('@dcl/sdk', true)
   if (!workspaceSdkVersion) {
     // no need to sync if the workspace does not have a dependency on @dcl/sdk
     return
   }
-  if (semver.lt(workspaceSdkVersion, extensionSdkVersion!)) {
+  if (semver.lt(workspaceSdkVersion, extensionSdkVersion)) {
     log(`Extension @dcl/sdk version: ${extensionSdkVersion}`)
     log(`Workspace @dcl/sdk version: ${workspaceSdkVersion}`)
-    log(
-      `Workspace @dcl/sdk version is older than the extension\'s, installing @dcl/sdk@${extensionSdkVersion} into workspace...`
-    )
-    await npmInstall(`@dcl/sdk@${extensionSdkVersion}`)
+    log(`Workspace @dcl/sdk version is older than the extension\'s`)
+    void warnOutdatedSdkVersion(extensionSdkVersion)
   }
   log(`Workspace @dcl/sdk version is up to date`)
 }


### PR DESCRIPTION
Prompt the user if they want to update the SDK instead of doing it automatically.

Allows the user to ignore this version to prevent showing the prompt on future activations of the extension.